### PR TITLE
Generalized Syncable Store Backing

### DIFF
--- a/code/cross-platform-packages/freedom-data-source-types/src/types/InMemoryDataSources.ts
+++ b/code/cross-platform-packages/freedom-data-source-types/src/types/InMemoryDataSources.ts
@@ -9,7 +9,7 @@ import { InMemoryLockStore } from 'freedom-locking-types';
 import type { InMemoryObjectStoreConstructorArgs, MutableObjectStore } from 'freedom-object-store-types';
 import { InMemoryObjectStore } from 'freedom-object-store-types';
 import type { MutableSyncableStore } from 'freedom-syncable-store-types';
-import { generateProvenanceForNewSyncableStore, InMemorySyncableStore } from 'freedom-syncable-store-types';
+import { generateProvenanceForNewSyncableStore, InMemorySyncableStore, InMemorySyncableStoreBacking } from 'freedom-syncable-store-types';
 
 import type { DataSources } from './DataSources.ts';
 import type { GetOrCreateIndexStoreArgs } from './GetOrCreateIndexStoreArgs.ts';
@@ -71,7 +71,9 @@ export class InMemoryDataSources implements DataSources {
       return provenance;
     }
 
-    const newStore = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    const storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+
+    const newStore = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     this.syncableStores_[cacheKey] = newStore;
     return makeSuccess(newStore);

--- a/code/cross-platform-packages/freedom-syncable-store-types/package.json
+++ b/code/cross-platform-packages/freedom-syncable-store-types/package.json
@@ -14,7 +14,6 @@
     "freedom-crypto-service": "0.0.0",
     "freedom-logging-types": "0.0.0",
     "freedom-notification-types": "0.0.0",
-    "freedom-object-store-types": "0.0.0",
     "freedom-sync-types": "0.0.0",
     "freedom-task-queue": "0.0.0",
     "freedom-trace-logging-and-metrics": "0.0.0",

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
@@ -117,11 +117,6 @@ export class FolderOperationsHandler {
   public readonly isPathMarkedAsDeleted = makeAsyncResultFunc(
     [import.meta.filename, 'isPathMarkedAsDeleted'],
     async (trace, path: StaticSyncablePath): PR<boolean> => {
-      const store = this.weakStore_.deref();
-      if (store === undefined) {
-        return makeFailure(new InternalStateError(trace, { message: 'store was released' }));
-      }
-
       // TODO: TEMP - this should work as a live document
       // if (this.storeChangesDoc_ === undefined) {
       const storeChangesDoc = await this.getMutableSyncableStoreChangesDocument_(trace);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/InMemoryAccessControlledFolder.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/InMemoryAccessControlledFolder.ts
@@ -1,53 +1,28 @@
-import type { StaticSyncablePath, SyncableProvenance } from 'freedom-sync-types';
-import { invalidProvenance } from 'freedom-sync-types';
+import type { StaticSyncablePath } from 'freedom-sync-types';
 
+import type { SyncableStoreBacking } from '../../types/backing/SyncableStoreBacking.ts';
 import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
 import type { SyncTracker } from '../../types/SyncTracker.ts';
 import { InMemoryAccessControlledFolderBase } from './InMemoryAccessControlledFolderBase.ts';
-import { InMemoryEncryptedBundle } from './InMemoryEncryptedBundle.ts';
-import { InMemoryFolder } from './InMemoryFolder.ts';
-import { InMemoryPlainBundle } from './InMemoryPlainBundle.ts';
 
 // TODO: need to figure out reasonable way of handling partially loaded data, especially for .access-control bundles, since both uploads and downloads are multi-part and async
 export class InMemoryAccessControlledFolder extends InMemoryAccessControlledFolderBase {
   constructor({
     store,
+    backing,
     syncTracker,
-    path,
-    provenance
+    path
   }: {
     store: WeakRef<MutableSyncableStore>;
+    backing: SyncableStoreBacking;
     syncTracker: SyncTracker;
     path: StaticSyncablePath;
-    provenance: SyncableProvenance;
   }) {
-    super({ syncTracker, path, provenance });
+    super({ backing, syncTracker, path });
 
-    const folderOperationsHandler = this.makeFolderOperationsHandler_(store);
     this.deferredInit_({
       store,
-      folderOperationsHandler,
-      plainBundle: new InMemoryPlainBundle({
-        store,
-        syncTracker,
-        folderOperationsHandler,
-        path,
-        provenance: invalidProvenance,
-        supportsDeletion: false
-      }),
-      folder: new InMemoryFolder({
-        store,
-        syncTracker,
-        folderOperationsHandler,
-        path
-      }),
-      encryptedBundle: new InMemoryEncryptedBundle({
-        store,
-        syncTracker,
-        folderOperationsHandler,
-        provenance: invalidProvenance,
-        path
-      })
+      makeFolderAccessor: ({ path }) => new InMemoryAccessControlledFolder({ store, backing, path, syncTracker })
     });
   }
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/InMemoryMutableFlatFileAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/InMemoryMutableFlatFileAccessor.ts
@@ -2,41 +2,40 @@ import type { PR, PRFunc } from 'freedom-async';
 import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
 import type { Sha256Hash } from 'freedom-basic-data';
 import { generalizeFailureResult } from 'freedom-common-errors';
+import { generateSha256HashFromBuffer } from 'freedom-crypto';
 import type { StaticSyncablePath, SyncableProvenance } from 'freedom-sync-types';
 
+import type { SyncableStoreBacking } from '../../types/backing/SyncableStoreBacking.ts';
 import type { FlatFileAccessor } from '../../types/FlatFileAccessor.ts';
 import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
 import { markSyncableNeedsRecomputeHashAtPath } from '../../utils/markSyncableNeedsRecomputeHashAtPath.ts';
-import { InMemoryMutableFileAccessorBase } from './InMemoryMutableFileAccessorBase.ts';
 
-export class InMemoryMutableFlatFileAccessor extends InMemoryMutableFileAccessorBase implements FlatFileAccessor {
+// TODO: rename to DefaultMutableFlatFileAccessor in separate PR
+export class InMemoryMutableFlatFileAccessor implements FlatFileAccessor {
   public readonly type = 'flatFile';
 
-  private readonly data_: Uint8Array;
-  private readonly hash_: Sha256Hash;
-  private readonly provenance_: SyncableProvenance;
+  public readonly path: StaticSyncablePath;
+
+  protected readonly weakStore_: WeakRef<MutableSyncableStore>;
+  protected readonly backing_: SyncableStoreBacking;
+
   private readonly decode_: PRFunc<Uint8Array, never, [encodedData: Uint8Array]>;
 
   constructor({
     store,
+    backing,
     path,
-    data,
-    hash,
-    provenance,
     decode
   }: {
     store: WeakRef<MutableSyncableStore>;
+    backing: SyncableStoreBacking;
     path: StaticSyncablePath;
-    data: Uint8Array;
-    hash: Sha256Hash;
-    provenance: SyncableProvenance;
     decode: PRFunc<Uint8Array, never, [encodedData: Uint8Array]>;
   }) {
-    super({ store, path });
+    this.weakStore_ = store;
+    this.backing_ = backing;
+    this.path = path;
 
-    this.data_ = data;
-    this.hash_ = hash;
-    this.provenance_ = provenance;
     this.decode_ = decode;
   }
 
@@ -44,8 +43,32 @@ export class InMemoryMutableFlatFileAccessor extends InMemoryMutableFileAccessor
 
   public readonly getHash = makeAsyncResultFunc(
     [import.meta.filename, 'getHash'],
-    async (_trace, _options?: { recompute?: boolean }): PR<Sha256Hash> => {
-      return makeSuccess(this.hash_);
+    async (trace, _options?: { recompute?: boolean }): PR<Sha256Hash> => {
+      const metadata = await this.backing_.getMetadataAtPath(trace, this.path);
+      if (!metadata.ok) {
+        return generalizeFailureResult(trace, metadata, ['not-found', 'wrong-type']);
+      }
+
+      if (metadata.value.hash !== undefined) {
+        return makeSuccess(metadata.value.hash);
+      }
+
+      const encodedBinary = await this.getEncodedBinary(trace);
+      if (!encodedBinary.ok) {
+        return encodedBinary;
+      }
+
+      const hash = await generateSha256HashFromBuffer(trace, encodedBinary.value);
+      if (!hash.ok) {
+        return hash;
+      }
+
+      const updatedMetadata = await this.backing_.updateLocalMetadataAtPath(trace, this.path, { hash: hash.value });
+      if (!updatedMetadata.ok) {
+        return generalizeFailureResult(trace, updatedMetadata, ['not-found', 'wrong-type']);
+      }
+
+      return makeSuccess(hash.value);
     }
   );
 
@@ -67,13 +90,22 @@ export class InMemoryMutableFlatFileAccessor extends InMemoryMutableFileAccessor
     }
   );
 
-  public readonly getEncodedBinary = makeAsyncResultFunc(
-    [import.meta.filename, 'getEncodedBinary'],
-    async (_trace): PR<Uint8Array> => makeSuccess(this.data_)
-  );
+  public readonly getEncodedBinary = makeAsyncResultFunc([import.meta.filename, 'getEncodedBinary'], async (trace): PR<Uint8Array> => {
+    const found = await this.backing_.getAtPath(trace, this.path, 'flatFile');
+    if (!found.ok) {
+      return generalizeFailureResult(trace, found, ['not-found', 'wrong-type']);
+    }
+
+    return await found.value.getBinary(trace);
+  });
 
   public readonly getBinary = makeAsyncResultFunc([import.meta.filename, 'getBinary'], async (trace): PR<Uint8Array> => {
-    const decoded = await this.decode_(trace, this.data_);
+    const encodedBinary = await this.getEncodedBinary(trace);
+    if (!encodedBinary.ok) {
+      return encodedBinary;
+    }
+
+    const decoded = await this.decode_(trace, encodedBinary.value);
     /* node:coverage disable */
     if (!decoded.ok) {
       return decoded;
@@ -83,8 +115,12 @@ export class InMemoryMutableFlatFileAccessor extends InMemoryMutableFileAccessor
     return makeSuccess(decoded.value);
   });
 
-  public readonly getProvenance = makeAsyncResultFunc(
-    [import.meta.filename, 'getProvenance'],
-    async (_trace): PR<SyncableProvenance> => makeSuccess(this.provenance_)
-  );
+  public readonly getProvenance = makeAsyncResultFunc([import.meta.filename, 'getProvenance'], async (trace): PR<SyncableProvenance> => {
+    const metadata = await this.backing_.getMetadataAtPath(trace, this.path);
+    if (!metadata.ok) {
+      return generalizeFailureResult(trace, metadata, ['not-found', 'wrong-type']);
+    }
+
+    return makeSuccess(metadata.value.provenance);
+  });
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
@@ -10,6 +10,7 @@ import { encId, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../../__test_dependency__/makeCryptoServiceForTesting.ts';
+import { InMemorySyncableStoreBacking } from '../../../types/in-memory-backing/InMemorySyncableStoreBacking.ts';
 import { InMemorySyncableStore } from '../../../types/InMemorySyncableStore.ts';
 import { createBinaryFileAtPath } from '../../../utils/create/createBinaryFileAtPath.ts';
 import { createBundleFileAtPath } from '../../../utils/create/createBundleFileAtPath.ts';
@@ -21,6 +22,7 @@ describe('hashes', () => {
   let trace!: Trace;
   let cryptoKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: CryptoService;
+  let storeBacking!: InMemorySyncableStoreBacking;
   let store!: InMemorySyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
@@ -37,7 +39,8 @@ describe('hashes', () => {
     const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
     expectOk(provenance);
 
-    store = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/utils/intersectSyncableItemTypes.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/utils/intersectSyncableItemTypes.ts
@@ -1,0 +1,15 @@
+import type { SyncableItemType } from 'freedom-sync-types';
+import type { SingleOrArray } from 'yaschema';
+
+export const intersectSyncableItemTypes = <T1 extends SyncableItemType, T2 extends SyncableItemType>(
+  a: SingleOrArray<T1> | undefined,
+  b: SingleOrArray<T2>
+): SingleOrArray<T1 & T2> => {
+  if (a === undefined) {
+    return b as SingleOrArray<T1 & T2>;
+  }
+
+  const aArray = Array.isArray(a) ? a : [a];
+  const bSet = new Set<any>(Array.isArray(b) ? b : [b]);
+  return aArray.filter((type) => bSet.has(type)) as Array<T1 & T2>;
+};

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/InMemorySyncableStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/InMemorySyncableStore.ts
@@ -4,16 +4,16 @@ import type { CryptoKeySetId } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
 import { NotificationManager } from 'freedom-notification-types';
 import type { StorageRootId, SyncableProvenance } from 'freedom-sync-types';
-import { invalidProvenance, StaticSyncablePath } from 'freedom-sync-types';
+import { StaticSyncablePath } from 'freedom-sync-types';
 
+import { InMemoryAccessControlledFolder } from '../internal/types/InMemoryAccessControlledFolder.ts';
 import { InMemoryAccessControlledFolderBase } from '../internal/types/InMemoryAccessControlledFolderBase.ts';
-import { InMemoryEncryptedBundle } from '../internal/types/InMemoryEncryptedBundle.ts';
-import { InMemoryFolder } from '../internal/types/InMemoryFolder.ts';
-import { InMemoryPlainBundle } from '../internal/types/InMemoryPlainBundle.ts';
+import type { SyncableStoreBacking } from './backing/SyncableStoreBacking.ts';
 import { InMemoryTrustMarkStore } from './InMemoryTrustMarkStore.ts';
 import type { MutableSyncableStore } from './MutableSyncableStore.ts';
 import type { SyncTrackerNotifications } from './SyncTracker.ts';
 
+// TODO: rename to DefaultSyncableStore in a separate PR
 export class InMemorySyncableStore extends InMemoryAccessControlledFolderBase implements MutableSyncableStore {
   public readonly creatorCryptoKeySetId: CryptoKeySetId;
   public readonly cryptoService: CryptoService;
@@ -22,17 +22,19 @@ export class InMemorySyncableStore extends InMemoryAccessControlledFolderBase im
 
   constructor({
     storageRootId,
+    backing,
     cryptoService,
     provenance
   }: {
     storageRootId: StorageRootId;
+    backing: SyncableStoreBacking;
     cryptoService: CryptoService;
     provenance: SyncableProvenance;
   }) {
     const syncTracker = new NotificationManager<SyncTrackerNotifications>();
     const path = new StaticSyncablePath(storageRootId);
 
-    super({ syncTracker, path, provenance });
+    super({ backing, syncTracker, path });
 
     this.cryptoService = cryptoService;
 
@@ -43,31 +45,9 @@ export class InMemorySyncableStore extends InMemoryAccessControlledFolderBase im
     this.creatorCryptoKeySetId = creatorCryptoKeySetId.value;
 
     const weakStore = new WeakRef(this);
-    const folderOperationsHandler = this.makeFolderOperationsHandler_(weakStore);
     this.deferredInit_({
       store: weakStore,
-      folderOperationsHandler,
-      plainBundle: new InMemoryPlainBundle({
-        store: weakStore,
-        syncTracker,
-        folderOperationsHandler,
-        path,
-        provenance: invalidProvenance,
-        supportsDeletion: false
-      }),
-      folder: new InMemoryFolder({
-        store: weakStore,
-        syncTracker,
-        folderOperationsHandler,
-        path
-      }),
-      encryptedBundle: new InMemoryEncryptedBundle({
-        store: weakStore,
-        syncTracker,
-        folderOperationsHandler,
-        provenance: invalidProvenance,
-        path
-      })
+      makeFolderAccessor: ({ path }) => new InMemoryAccessControlledFolder({ store: weakStore, backing, path, syncTracker })
     });
   }
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/LocalItemMetadata.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/LocalItemMetadata.ts
@@ -1,0 +1,7 @@
+import { sha256HashInfo } from 'freedom-basic-data';
+import { schema } from 'yaschema';
+
+export const localItemMetadataSchema = schema.object({
+  hash: sha256HashInfo.schema.optional()
+});
+export type LocalItemMetadata = typeof localItemMetadataSchema.valueType;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/MutableAccessControlledFolderAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/MutableAccessControlledFolderAccessor.ts
@@ -2,11 +2,16 @@ import type { AccessChangeParams } from 'freedom-access-control-types';
 import type { PRFunc } from 'freedom-async';
 
 import type { AccessControlledFolderAccessor } from './AccessControlledFolderAccessor.ts';
+import type { FolderManagement } from './FolderManagement.ts';
 import type { MutableFileStore } from './MutableFileStore.ts';
 import type { MutableFolderStore } from './MutableFolderStore.ts';
 import type { SyncableStoreRole } from './SyncableStoreRole.ts';
 
-export interface MutableAccessControlledFolderAccessor extends AccessControlledFolderAccessor, MutableFileStore, MutableFolderStore {
+export interface MutableAccessControlledFolderAccessor
+  extends AccessControlledFolderAccessor,
+    MutableFileStore,
+    MutableFolderStore,
+    FolderManagement {
   /** Updates access levels */
   readonly updateAccess: PRFunc<undefined, 'conflict', [change: AccessChangeParams<SyncableStoreRole>]>;
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/MutableBundleFileAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/MutableBundleFileAccessor.ts
@@ -1,7 +1,8 @@
 import type { BundleFileAccessor } from './BundleFileAccessor.ts';
+import type { BundleManagement } from './BundleManagement.ts';
 import type { MutableFileAccessorBase } from './MutableFileAccessorBase.ts';
 import type { MutableFileStore } from './MutableFileStore.ts';
 
-export interface MutableBundleFileAccessor extends BundleFileAccessor, MutableFileAccessorBase, MutableFileStore {
+export interface MutableBundleFileAccessor extends BundleFileAccessor, MutableFileAccessorBase, MutableFileStore, BundleManagement {
   readonly type: 'bundleFile';
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/InMemorySyncableStore.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/InMemorySyncableStore.test.ts
@@ -19,12 +19,14 @@ import { getFolderAtPath } from '../../utils/get/getFolderAtPath.ts';
 import { getMutableFolderAtPath } from '../../utils/get/getMutableFolderAtPath.ts';
 import { getStringFromFileAtPath } from '../../utils/get/getStringFromFileAtPath.ts';
 import { initializeRoot } from '../../utils/initializeRoot.ts';
+import { InMemorySyncableStoreBacking } from '../in-memory-backing/InMemorySyncableStoreBacking.ts';
 import { InMemorySyncableStore } from '../InMemorySyncableStore.ts';
 
 describe('InMemorySyncableStore', () => {
   let trace!: Trace;
   let cryptoKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: CryptoService;
+  let storeBacking!: InMemorySyncableStoreBacking;
   let store!: InMemorySyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
@@ -41,7 +43,8 @@ describe('InMemorySyncableStore', () => {
     const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
     expectOk(provenance);
 
-    store = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/SyncableStoreBacking.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/SyncableStoreBacking.ts
@@ -1,0 +1,61 @@
+import type { PR, PRFunc } from 'freedom-async';
+import type { Trace } from 'freedom-contexts';
+import type {
+  StaticSyncablePath,
+  SyncableBundleFileMetadata,
+  SyncableFlatFileMetadata,
+  SyncableFolderMetadata,
+  SyncableId,
+  SyncableItemMetadata,
+  SyncableItemType
+} from 'freedom-sync-types';
+import type { SingleOrArray } from 'yaschema';
+
+import type { LocalItemMetadata } from '../LocalItemMetadata.ts';
+import type { SyncableStoreBackingFlatFileAccessor } from './accessors/SyncableStoreBackingFlatFileAccessor.ts';
+import type { SyncableStoreBackingFolderAccessor } from './accessors/SyncableStoreBackingFolderAccessor.ts';
+import type { SyncableStoreBackingItemAccessor } from './accessors/SyncableStoreBackingItemAccessor.ts';
+
+export interface SyncableStoreBacking {
+  readonly existsAtPath: PRFunc<boolean, never, [path: StaticSyncablePath]>;
+
+  readonly getAtPath: <T extends SyncableItemType = SyncableItemType>(
+    trace: Trace,
+    path: StaticSyncablePath,
+    expectedType?: SingleOrArray<T>
+  ) => PR<SyncableStoreBackingItemAccessor & { type: T }, 'not-found' | 'wrong-type'>;
+
+  readonly getIdsInPath: PRFunc<
+    SyncableId[],
+    'not-found' | 'wrong-type',
+    [path: StaticSyncablePath, options?: { type?: SingleOrArray<SyncableItemType> }]
+  >;
+
+  readonly getMetadataAtPath: PRFunc<SyncableItemMetadata & LocalItemMetadata, 'not-found' | 'wrong-type', [path: StaticSyncablePath]>;
+
+  readonly getMetadataByIdInPath: PRFunc<
+    Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>,
+    'not-found' | 'wrong-type',
+    [path: StaticSyncablePath, ids?: Set<SyncableId>]
+  >;
+
+  readonly createBinaryFileWithPath: PRFunc<
+    SyncableStoreBackingFlatFileAccessor,
+    'not-found' | 'wrong-type' | 'conflict',
+    [path: StaticSyncablePath, { data: Uint8Array; metadata: SyncableFlatFileMetadata & LocalItemMetadata }]
+  >;
+
+  readonly createFolderWithPath: PRFunc<
+    SyncableStoreBackingFolderAccessor,
+    'not-found' | 'wrong-type' | 'conflict',
+    [path: StaticSyncablePath, { metadata: (SyncableFolderMetadata | SyncableBundleFileMetadata) & LocalItemMetadata }]
+  >;
+
+  readonly deleteAtPath: PRFunc<undefined, 'not-found' | 'wrong-type', [path: StaticSyncablePath]>;
+
+  readonly updateLocalMetadataAtPath: PRFunc<
+    undefined,
+    'not-found' | 'wrong-type',
+    [path: StaticSyncablePath, metadata: Partial<LocalItemMetadata>]
+  >;
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingFlatFileAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingFlatFileAccessor.ts
@@ -1,0 +1,8 @@
+import type { PRFunc } from 'freedom-async';
+import type { SyncableId } from 'freedom-sync-types';
+
+export interface SyncableStoreBackingFlatFileAccessor {
+  type: 'flatFile';
+  id: SyncableId;
+  getBinary: PRFunc<Uint8Array>;
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingFolderAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingFolderAccessor.ts
@@ -1,0 +1,6 @@
+import type { SyncableId } from 'freedom-sync-types';
+
+export interface SyncableStoreBackingFolderAccessor {
+  readonly type: 'folder';
+  readonly id: SyncableId;
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingItemAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/SyncableStoreBackingItemAccessor.ts
@@ -1,0 +1,4 @@
+import type { SyncableStoreBackingFlatFileAccessor } from './SyncableStoreBackingFlatFileAccessor.ts';
+import type { SyncableStoreBackingFolderAccessor } from './SyncableStoreBackingFolderAccessor.ts';
+
+export type SyncableStoreBackingItemAccessor = SyncableStoreBackingFolderAccessor | SyncableStoreBackingFlatFileAccessor;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/accessors/exports.ts
@@ -1,0 +1,3 @@
+export * from './SyncableStoreBackingFlatFileAccessor.ts';
+export * from './SyncableStoreBackingFolderAccessor.ts';
+export * from './SyncableStoreBackingItemAccessor.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/backing/exports.ts
@@ -1,0 +1,2 @@
+export * from './accessors/exports.ts';
+export * from './SyncableStoreBacking.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/exports.ts
@@ -9,6 +9,7 @@ export * from './FolderManagement.ts';
 export * from './FolderStore.ts';
 export * from './GenerateNewSyncableItemIdFunc.ts';
 export * from './InMemorySyncableStore.ts';
+export * from './LocalItemMetadata.ts';
 export * from './MutableAccessControlledFolderAccessor.ts';
 export * from './MutableBundleFileAccessor.ts';
 export * from './MutableFileAccessor.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/exports.ts
@@ -1,4 +1,5 @@
 export * from './AccessControlledFolderAccessor.ts';
+export * from './backing/exports.ts';
 export * from './BundleFileAccessor.ts';
 export * from './BundleManagement.ts';
 export * from './FileAccessor.ts';
@@ -8,8 +9,8 @@ export * from './FlatFileAccessor.ts';
 export * from './FolderManagement.ts';
 export * from './FolderStore.ts';
 export * from './GenerateNewSyncableItemIdFunc.ts';
+export * from './in-memory-backing/exports.ts';
 export * from './InMemorySyncableStore.ts';
-export * from './LocalItemMetadata.ts';
 export * from './MutableAccessControlledFolderAccessor.ts';
 export * from './MutableBundleFileAccessor.ts';
 export * from './MutableFileAccessor.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/InMemorySyncableStoreBacking.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/InMemorySyncableStoreBacking.ts
@@ -1,0 +1,254 @@
+import { excludeFailureResult, makeAsyncResultFunc, makeFailure, makeSuccess, type PR } from 'freedom-async';
+import { objectEntries } from 'freedom-cast';
+import { ConflictError, generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import {
+  type StaticSyncablePath,
+  type SyncableBundleFileMetadata,
+  type SyncableFlatFileMetadata,
+  type SyncableFolderMetadata,
+  type SyncableId,
+  type SyncableItemMetadata,
+  type SyncableItemType,
+  syncableItemTypes
+} from 'freedom-sync-types';
+import type { SingleOrArray } from 'yaschema';
+
+import { isExpectedType } from '../../utils/validation/isExpectedType.ts';
+import type { SyncableStoreBackingFlatFileAccessor } from '../backing/accessors/SyncableStoreBackingFlatFileAccessor.ts';
+import type { SyncableStoreBackingFolderAccessor } from '../backing/accessors/SyncableStoreBackingFolderAccessor.ts';
+import type { SyncableStoreBackingItemAccessor } from '../backing/accessors/SyncableStoreBackingItemAccessor.ts';
+import type { SyncableStoreBacking } from '../backing/SyncableStoreBacking.ts';
+import type { LocalItemMetadata } from '../LocalItemMetadata.ts';
+import { ROOT_FOLDER_ID } from './internal/consts/special-ids.ts';
+import type { InMemorySyncableStoreBackingFlatFileItem } from './internal/types/InMemorySyncableStoreBackingFlatFileItem.ts';
+import type { InMemorySyncableStoreBackingFolderItem } from './internal/types/InMemorySyncableStoreBackingFolderItem.ts';
+import { makeFlatFileAccessor } from './internal/utils/makeFlatFileAccessor.ts';
+import { makeFolderAccessor } from './internal/utils/makeFolderAccessor.ts';
+import { makeItemAccessor } from './internal/utils/makeItemAccessor.ts';
+import { traversePath } from './internal/utils/traversePath.ts';
+
+export class InMemorySyncableStoreBacking implements SyncableStoreBacking {
+  private readonly root_: InMemorySyncableStoreBackingFolderItem;
+
+  constructor(metadata: Omit<SyncableFolderMetadata & LocalItemMetadata, 'type' | 'encrypted'>) {
+    this.root_ = {
+      type: 'folder',
+      id: ROOT_FOLDER_ID,
+      metadata: { ...metadata, type: 'folder', encrypted: true },
+      contents: {}
+    };
+  }
+
+  public readonly existsAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'existsAtPath'],
+    async (trace, path: StaticSyncablePath): PR<boolean> => {
+      const found = traversePath(trace, this.root_, path);
+      if (!found.ok) {
+        if (found.value.errorCode === 'not-found') {
+          return makeSuccess(false);
+        }
+
+        return generalizeFailureResult(trace, excludeFailureResult(found, 'not-found'), 'wrong-type');
+      }
+
+      return makeSuccess(found.value !== undefined);
+    }
+  );
+
+  public readonly getAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getAtPath'],
+    async <T extends SyncableItemType = SyncableItemType>(
+      trace: Trace,
+      path: StaticSyncablePath,
+      expectedType?: SingleOrArray<T>
+    ): PR<SyncableStoreBackingItemAccessor & { type: T }, 'not-found' | 'wrong-type'> => {
+      const found = traversePath(trace, this.root_, path, expectedType);
+      if (!found.ok) {
+        return found;
+      }
+
+      const accessor = makeItemAccessor(trace, found.value);
+      return makeSuccess(accessor as SyncableStoreBackingItemAccessor & { type: T });
+    }
+  );
+
+  public readonly getIdsInPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getIdsInPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      options?: { type?: SingleOrArray<SyncableItemType> }
+    ): PR<SyncableId[], 'not-found' | 'wrong-type'> => {
+      const found = traversePath(trace, this.root_, path, syncableItemTypes.exclude('flatFile'));
+      if (!found.ok) {
+        return found;
+      }
+
+      const ids = objectEntries(found.value.contents)
+        .filter(([_id, item]) => {
+          if (item === undefined) {
+            return false;
+          }
+
+          const isExpected = isExpectedType(trace, item.metadata, options?.type);
+          return isExpected.ok && isExpected.value;
+        })
+        .map(([id, _item]) => id);
+      return makeSuccess(ids);
+    }
+  );
+
+  public readonly getMetadataAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getMetadataAtPath'],
+    async (trace, path: StaticSyncablePath): PR<SyncableItemMetadata & LocalItemMetadata, 'not-found' | 'wrong-type'> => {
+      if (path.ids.length === 0) {
+        return makeSuccess(this.root_.metadata);
+      }
+
+      const id = path.lastId!;
+      const metadataById = await this.getMetadataByIdInPath(trace, path.parentPath!, new Set([id]));
+      if (!metadataById.ok) {
+        return metadataById;
+      }
+
+      if (metadataById.value[id] === undefined) {
+        return makeFailure(new NotFoundError(trace, { message: `No metadata found for ${path.toString()}`, errorCode: 'not-found' }));
+      }
+
+      return makeSuccess(metadataById.value[id]);
+    }
+  );
+
+  public readonly getMetadataByIdInPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getMetadataByIdInPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      ids?: Set<SyncableId>
+    ): PR<Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>, 'not-found' | 'wrong-type'> => {
+      const found = traversePath(trace, this.root_, path, syncableItemTypes.exclude('flatFile'));
+      if (!found.ok) {
+        return found;
+      }
+
+      const metadataById = objectEntries(found.value.contents)
+        .filter(([id, item]) => {
+          if (item === undefined) {
+            return false;
+          }
+
+          return ids === undefined || ids.has(id);
+        })
+        .reduce(
+          (out, [id, item]) => {
+            out[id] = item!.metadata;
+            return out;
+          },
+          {} as Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>
+        );
+      return makeSuccess(metadataById);
+    }
+  );
+
+  public readonly createBinaryFileWithPath = makeAsyncResultFunc(
+    [import.meta.filename, 'createBinaryFileWithPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      { data, metadata }: { data: Uint8Array; metadata: SyncableFlatFileMetadata & LocalItemMetadata }
+    ): PR<SyncableStoreBackingFlatFileAccessor, 'not-found' | 'wrong-type' | 'conflict'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      if (foundParent.value.contents[path.lastId!] !== undefined) {
+        return makeFailure(new ConflictError(trace, { message: `${path.toString()} already exists`, errorCode: 'conflict' }));
+      }
+
+      const newItem: InMemorySyncableStoreBackingFlatFileItem = {
+        type: 'flatFile',
+        id: path.lastId!,
+        metadata,
+        data
+      };
+      foundParent.value.contents[path.lastId!] = newItem;
+
+      return makeSuccess(makeFlatFileAccessor(trace, newItem));
+    }
+  );
+
+  public readonly createFolderWithPath = makeAsyncResultFunc(
+    [import.meta.filename, 'createFolderWithPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      { metadata }: { metadata: (SyncableBundleFileMetadata | SyncableFolderMetadata) & LocalItemMetadata }
+    ): PR<SyncableStoreBackingFolderAccessor, 'not-found' | 'wrong-type' | 'conflict'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      if (foundParent.value.contents[path.lastId!] !== undefined) {
+        return makeFailure(new ConflictError(trace, { message: `${path.toString()} already exists`, errorCode: 'conflict' }));
+      }
+
+      const newItem: InMemorySyncableStoreBackingFolderItem = {
+        type: 'folder',
+        id: path.lastId!,
+        metadata,
+        contents: {}
+      };
+      foundParent.value.contents[path.lastId!] = newItem;
+
+      return makeSuccess(makeFolderAccessor(trace, newItem));
+    }
+  );
+
+  public readonly deleteAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'deleteAtPath'],
+    async (trace, path: StaticSyncablePath): PR<undefined, 'not-found' | 'wrong-type'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      delete foundParent.value.contents[path.lastId!];
+
+      return makeSuccess(undefined);
+    }
+  );
+
+  public readonly updateLocalMetadataAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'updateLocalMetadataAtPath'],
+    async (trace, path: StaticSyncablePath, metadata: Partial<LocalItemMetadata>): PR<undefined, 'not-found' | 'wrong-type'> => {
+      const found = traversePath(trace, this.root_, path);
+      if (!found.ok) {
+        return found;
+      }
+
+      if ('hash' in metadata) {
+        found.value.metadata.hash = metadata.hash;
+      }
+
+      return makeSuccess(undefined);
+    }
+  );
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/exports.ts
@@ -1,0 +1,1 @@
+export * from './InMemorySyncableStoreBacking.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
@@ -1,0 +1,4 @@
+import { plainId } from 'freedom-sync-types';
+
+/** This is only used as an internal marker */
+export const ROOT_FOLDER_ID = plainId('root');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingFlatFileItem.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingFlatFileItem.ts
@@ -1,0 +1,10 @@
+import type { SyncableId, SyncableItemMetadata } from 'freedom-sync-types';
+
+import type { LocalItemMetadata } from '../../../LocalItemMetadata.ts';
+
+export interface InMemorySyncableStoreBackingFlatFileItem {
+  readonly type: 'flatFile';
+  readonly id: SyncableId;
+  readonly metadata: SyncableItemMetadata & { type: 'flatFile' } & LocalItemMetadata;
+  readonly data: Uint8Array;
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingFolderItem.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingFolderItem.ts
@@ -1,0 +1,11 @@
+import type { SyncableBundleFileMetadata, SyncableFolderMetadata, SyncableId } from 'freedom-sync-types';
+
+import type { LocalItemMetadata } from '../../../LocalItemMetadata.ts';
+import type { InMemorySyncableStoreBackingItem } from './InMemorySyncableStoreBackingItem.ts';
+
+export interface InMemorySyncableStoreBackingFolderItem {
+  readonly type: 'folder';
+  readonly id: SyncableId;
+  readonly contents: Partial<Record<SyncableId, InMemorySyncableStoreBackingItem>>;
+  readonly metadata: (SyncableBundleFileMetadata | SyncableFolderMetadata) & LocalItemMetadata;
+}

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingItem.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/types/InMemorySyncableStoreBackingItem.ts
@@ -1,0 +1,4 @@
+import type { InMemorySyncableStoreBackingFlatFileItem } from './InMemorySyncableStoreBackingFlatFileItem.ts';
+import type { InMemorySyncableStoreBackingFolderItem } from './InMemorySyncableStoreBackingFolderItem.ts';
+
+export type InMemorySyncableStoreBackingItem = InMemorySyncableStoreBackingFolderItem | InMemorySyncableStoreBackingFlatFileItem;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeFlatFileAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeFlatFileAccessor.ts
@@ -1,0 +1,16 @@
+import { makeSuccess, makeSyncFunc } from 'freedom-async';
+
+import type { SyncableStoreBackingFlatFileAccessor } from '../../../backing/accessors/SyncableStoreBackingFlatFileAccessor.ts';
+import type { InMemorySyncableStoreBackingFlatFileItem } from '../types/InMemorySyncableStoreBackingFlatFileItem.ts';
+
+export const makeFlatFileAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (_trace, item: InMemorySyncableStoreBackingFlatFileItem): SyncableStoreBackingFlatFileAccessor => {
+    const data = item.data;
+    return {
+      type: 'flatFile',
+      id: item.id,
+      getBinary: async () => makeSuccess(data)
+    };
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeFolderAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeFolderAccessor.ts
@@ -1,0 +1,12 @@
+import { makeSyncFunc } from 'freedom-async';
+
+import type { SyncableStoreBackingFolderAccessor } from '../../../backing/accessors/SyncableStoreBackingFolderAccessor.ts';
+import type { InMemorySyncableStoreBackingFolderItem } from '../types/InMemorySyncableStoreBackingFolderItem.ts';
+
+export const makeFolderAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (_trace, item: InMemorySyncableStoreBackingFolderItem): SyncableStoreBackingFolderAccessor => ({
+    type: 'folder',
+    id: item.id
+  })
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeItemAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/makeItemAccessor.ts
@@ -1,0 +1,19 @@
+import { makeSyncFunc } from 'freedom-async';
+
+import type { SyncableStoreBackingItemAccessor } from '../../../backing/accessors/SyncableStoreBackingItemAccessor.ts';
+import type { InMemorySyncableStoreBackingItem } from '../types/InMemorySyncableStoreBackingItem.ts';
+import { makeFlatFileAccessor } from './makeFlatFileAccessor.ts';
+import { makeFolderAccessor } from './makeFolderAccessor.ts';
+
+export const makeItemAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (trace, item: InMemorySyncableStoreBackingItem): SyncableStoreBackingItemAccessor => {
+    switch (item.type) {
+      case 'folder':
+        return makeFolderAccessor(trace, item);
+
+      case 'flatFile':
+        return makeFlatFileAccessor(trace, item);
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/traversePath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/traversePath.ts
@@ -1,0 +1,74 @@
+import { makeFailure, makeSuccess, makeSyncResultFunc, type Result } from 'freedom-async';
+import { NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import type { SyncableId, SyncableItemType } from 'freedom-sync-types';
+import { StaticSyncablePath } from 'freedom-sync-types';
+import type { SingleOrArray } from 'yaschema';
+
+import { guardIsExpectedType } from '../../../../utils/guards/guardIsExpectedType.ts';
+import type { InMemorySyncableStoreBackingItem } from '../types/InMemorySyncableStoreBackingItem.ts';
+
+type BackingTypeBySyncableItemType<T extends SyncableItemType> =
+  | (T extends 'flatFile' ? 'flatFile' : never)
+  | (T extends 'bundleFile' ? 'folder' : never)
+  | (T extends 'folder' ? 'folder' : never);
+
+export const traversePath = makeSyncResultFunc(
+  [import.meta.filename],
+  <T extends SyncableItemType = SyncableItemType>(
+    trace: Trace,
+    item: InMemorySyncableStoreBackingItem,
+    path: StaticSyncablePath,
+    expectedType?: SingleOrArray<T>
+  ): Result<
+    InMemorySyncableStoreBackingItem & {
+      type: BackingTypeBySyncableItemType<T>;
+      metadata: InMemorySyncableStoreBackingItem['metadata'] & { type: T };
+    },
+    'not-found' | 'wrong-type'
+  > => {
+    const idsSoFar: SyncableId[] = [];
+
+    let cursor: InMemorySyncableStoreBackingItem = item;
+    for (const pathId of path.ids) {
+      idsSoFar.push(pathId);
+
+      switch (cursor.type) {
+        case 'flatFile':
+          return makeFailure(
+            new NotFoundError(trace, {
+              message: `Expected folder or bundleFile, found: ${cursor.type}`,
+              errorCode: 'wrong-type'
+            })
+          );
+
+        case 'folder': {
+          const nextCursor = cursor.contents[pathId];
+
+          if (nextCursor === undefined) {
+            return makeFailure(
+              new NotFoundError(trace, {
+                message: `No item found at ${new StaticSyncablePath(path.storageRootId, ...idsSoFar).toString()}`,
+                errorCode: 'not-found'
+              })
+            );
+          }
+
+          cursor = nextCursor;
+        }
+      }
+    }
+
+    const guards = guardIsExpectedType(trace, path, cursor.metadata, expectedType, 'wrong-type');
+    if (!guards.ok) {
+      return guards;
+    }
+
+    return makeSuccess(
+      cursor as InMemorySyncableStoreBackingItem & {
+        type: BackingTypeBySyncableItemType<T>;
+        metadata: InMemorySyncableStoreBackingItem['metadata'] & { type: T };
+      }
+    );
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
@@ -13,6 +13,7 @@ import { encId, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
+import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMemorySyncableStoreBacking.ts';
 import { InMemorySyncableStore } from '../../types/InMemorySyncableStore.ts';
 import { createConflictFreeDocumentBundleAtPath } from '../create/createConflictFreeDocumentBundleAtPath.ts';
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
@@ -24,6 +25,7 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
   let trace!: Trace;
   let cryptoKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: CryptoService;
+  let storeBacking!: InMemorySyncableStoreBacking;
   let store!: InMemorySyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
@@ -40,7 +42,8 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
     const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
     expectOk(provenance);
 
-    store = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
@@ -11,6 +11,7 @@ import { expectOk } from 'freedom-testing-tools';
 import { schema } from 'yaschema';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
+import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMemorySyncableStoreBacking.ts';
 import { InMemorySyncableStore } from '../../types/InMemorySyncableStore.ts';
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
 import { createJsonFileAtPath } from '../create/createJsonFileAtPath.ts';
@@ -24,6 +25,7 @@ describe('createJsonFileAtPath', () => {
   let trace!: Trace;
   let cryptoKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: CryptoService;
+  let storeBacking!: InMemorySyncableStoreBacking;
   let store!: InMemorySyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
@@ -40,7 +42,8 @@ describe('createJsonFileAtPath', () => {
     const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
     expectOk(provenance);
 
-    store = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
@@ -10,6 +10,7 @@ import { encId, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
+import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMemorySyncableStoreBacking.ts';
 import { InMemorySyncableStore } from '../../types/InMemorySyncableStore.ts';
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
 import { createStringFileAtPath } from '../create/createStringFileAtPath.ts';
@@ -21,6 +22,7 @@ describe('createStringFileAtPath', () => {
   let trace!: Trace;
   let cryptoKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: CryptoService;
+  let storeBacking!: InMemorySyncableStoreBacking;
   let store!: InMemorySyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
@@ -37,7 +39,8 @@ describe('createStringFileAtPath', () => {
     const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
     expectOk(provenance);
 
-    store = new InMemorySyncableStore({ storageRootId, cryptoService, provenance: provenance.value });
+    storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/exports.ts
@@ -1,6 +1,7 @@
 export * from './getBinaryFromFileAtPath.ts';
 export * from './getBundleFileAtPath.ts';
 export * from './getConflictFreeDocumentFromBundleAtPath.ts';
+export * from './getDynamicIds.ts';
 export * from './getFolderAtPath.ts';
 export * from './getFolderPath.ts';
 export * from './getJsonFromFileAtPath.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getMutableSyncableAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getMutableSyncableAtPath.ts
@@ -32,7 +32,7 @@ export const getMutableSyncableAtPath = makeAsyncResultFunc(
     }
 
     if (path.ids.length === 0) {
-      const guards = await guardIsExpectedType(trace, new StaticSyncablePath(path.storageRootId), store, expectedType, 'wrong-type');
+      const guards = guardIsExpectedType(trace, new StaticSyncablePath(path.storageRootId), store, expectedType, 'wrong-type');
       if (!guards.ok) {
         return generalizeFailureResult(trace, guards, 'wrong-type');
       }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getSyncableAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getSyncableAtPath.ts
@@ -31,7 +31,7 @@ export const getSyncableAtPath = makeAsyncResultFunc(
     }
 
     if (path.ids.length === 0) {
-      const guards = await guardIsExpectedType(trace, new StaticSyncablePath(path.storageRootId), store, expectedType, 'wrong-type');
+      const guards = guardIsExpectedType(trace, new StaticSyncablePath(path.storageRootId), store, expectedType, 'wrong-type');
       if (!guards.ok) {
         return generalizeFailureResult(trace, guards, 'wrong-type');
       }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/guards/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/guards/exports.ts
@@ -1,3 +1,2 @@
 export * from './guardIsExpectedType.ts';
 export * from './guardIsProvenanceValid.ts';
-export * from './guardIsSyncableItemAcceptedOrWasWriteLegit.ts';

--- a/code/freedom-email.code-workspace
+++ b/code/freedom-email.code-workspace
@@ -115,6 +115,9 @@
             "path": "dev-packages/freedom-testing-tools"
         },
         {
+            "path": "server-packages/freedom-file-system-syncable-store-backing"
+        },
+        {
             "path": "server-packages/freedom-server-api-handling"
         },
         {

--- a/code/server-packages/freedom-file-system-syncable-store-backing/package.json
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/package.json
@@ -1,0 +1,37 @@
+{
+  "dependencies": {
+    "freedom-syncable-store-types": "0.0.0",
+    "freedom-sync-types": "0.0.0",
+    "lodash-es": "4.17.21",
+    "yaschema": "4.4.2"
+  },
+  "devDependencies": {
+    "@types/lodash-es": "4.17.12",
+    "freedom-build-tools": "0.0.0",
+    "typescript": "5.8.2"
+  },
+  "type": "module",
+  "main": "lib/mjs/exports.mjs",
+  "name": "freedom-file-system-syncable-store-backing",
+  "nx": {
+    "tags": [
+      "type:lib",
+      "platform:server"
+    ]
+  },
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.mjs.json --emitDeclarationOnly && ../../dev-packages/freedom-build-tools/lib/mjs/freedom-build.js --tsconfig tsconfig.mjs.json",
+    "build:dev": "FREEDOM_BUILD_MODE=DEV yarn build",
+    "build:tests": "tsc",
+    "clean": "rimraf ./coverage ./lib",
+    "depcheck": "depcheck --ignores=freedom-build-tools,@types/multer || (code ./package.json && exit 1)",
+    "lint": "eslint 'src/**/*.ts?(x)' --max-warnings 0",
+    "test": "yarn test:unit-tests",
+    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOG_ALLOW_BLOCKING=${FREEDOM_LOG_ALLOW_BLOCKING:-false} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:unit-tests": "NODE_OPTIONS='--experimental-transform-types --disable-warning=ExperimentalWarning' node --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=90000 --test"
+  },
+  "types": "lib/exports.d.ts",
+  "version": "0.0.0"
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/__test_dependency__/makeCryptoServiceForTesting.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/__test_dependency__/makeCryptoServiceForTesting.ts
@@ -1,0 +1,63 @@
+/* node:coverage disable */
+
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalStateError } from 'freedom-common-errors';
+import type { CombinationCryptoKeySet, CryptoKeySetId, PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
+import type { CryptoService } from 'freedom-crypto-service';
+import { makeCryptoService } from 'freedom-crypto-service';
+
+export interface TestingCryptoService extends CryptoService {
+  addPublicKeys: (args: { publicKeys: CombinationCryptoKeySet }) => void;
+}
+
+export const makeCryptoServiceForTesting = ({ cryptoKeys }: { cryptoKeys: PrivateCombinationCryptoKeySet }): TestingCryptoService => {
+  const allPublicKeys: Partial<Record<CryptoKeySetId, CombinationCryptoKeySet>> = {};
+
+  const cryptoService = makeCryptoService({
+    getCryptoKeySetIds: makeAsyncResultFunc(
+      [import.meta.filename, 'getCryptoKeySetIds'],
+      async (_trace): PR<CryptoKeySetId[]> => makeSuccess([cryptoKeys.id])
+    ),
+
+    getCryptoKeysById: makeAsyncResultFunc(
+      [import.meta.filename, 'getCryptoKeysById'],
+      async (trace, id): PR<PrivateCombinationCryptoKeySet, 'not-found'> => {
+        if (id === cryptoKeys.id) {
+          return makeSuccess(cryptoKeys);
+        }
+
+        return makeFailure(new InternalStateError(trace, { message: `Key not found with ID: ${id}`, errorCode: 'not-found' }));
+      }
+    ),
+
+    getPublicCryptoKeysById: makeAsyncResultFunc(
+      [import.meta.filename, 'getPublicCryptoKeysById'],
+      async (trace, id): PR<CombinationCryptoKeySet, 'not-found'> => {
+        if (id === cryptoKeys.id) {
+          return makeSuccess(cryptoKeys);
+        }
+
+        const found = allPublicKeys[id];
+        if (found !== undefined) {
+          return makeSuccess(found);
+        }
+
+        return makeFailure(new InternalStateError(trace, { message: `Key not found with ID: ${id}`, errorCode: 'not-found' }));
+      }
+    ),
+
+    getMostRecentCryptoKeys: makeAsyncResultFunc(
+      [import.meta.filename, 'getMostRecentCryptoKeys'],
+      async (_trace): PR<PrivateCombinationCryptoKeySet> => makeSuccess(cryptoKeys)
+    )
+  });
+
+  const modifiedCryptoService = cryptoService as Partial<TestingCryptoService>;
+
+  modifiedCryptoService.addPublicKeys = ({ publicKeys }) => {
+    allPublicKeys[publicKeys.id] = publicKeys;
+  };
+
+  return modifiedCryptoService as TestingCryptoService;
+};

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/exports.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/exports.ts
@@ -1,0 +1,1 @@
+export * from './types/exports.ts';

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/consts/special-ids.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/consts/special-ids.ts
@@ -1,0 +1,4 @@
+import { plainId } from 'freedom-sync-types';
+
+/** This is only used as an internal marker */
+export const ROOT_FOLDER_ID = plainId('root');

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/AnyMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/AnyMetadata.ts
@@ -1,0 +1,7 @@
+import { schema } from 'yaschema';
+
+import { flatFileMetadataSchema } from './FlatFileMetadata.ts';
+import { folderMetadataSchema } from './FolderMetadata.ts';
+
+export const anyMetadataSchema = schema.oneOf(flatFileMetadataSchema, folderMetadataSchema);
+export type AnyMetadata = typeof anyMetadataSchema.valueType;

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemLocalItemMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemLocalItemMetadata.ts
@@ -1,0 +1,16 @@
+import { sha256HashInfo } from 'freedom-basic-data';
+import { syncableIdSchema } from 'freedom-sync-types';
+import { schema } from 'yaschema';
+
+export const fileSystemChangeableLocalItemMetadataSchema = schema.object({
+  hash: sha256HashInfo.schema.optional()
+});
+export type FileSystemChangeableLocalItemMetadata = typeof fileSystemChangeableLocalItemMetadataSchema.valueType;
+
+export const fileSystemLocalItemMetadataSchema = schema.extendsObject(
+  fileSystemChangeableLocalItemMetadataSchema,
+  schema.object({
+    id: syncableIdSchema
+  })
+);
+export type FileSystemLocalItemMetadata = typeof fileSystemLocalItemMetadataSchema.valueType;

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingFlatFileItem.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingFlatFileItem.ts
@@ -1,0 +1,11 @@
+import type { PRFunc } from 'freedom-async';
+import type { SyncableId, SyncableItemMetadata } from 'freedom-sync-types';
+
+import type { FileSystemLocalItemMetadata } from './FileSystemLocalItemMetadata.ts';
+
+export interface FileSystemSyncableStoreBackingFlatFileItem {
+  readonly type: 'flatFile';
+  readonly id: SyncableId;
+  readonly metadata: PRFunc<SyncableItemMetadata & { type: 'flatFile' } & FileSystemLocalItemMetadata, 'not-found' | 'wrong-type'>;
+  readonly data: PRFunc<Uint8Array, 'not-found' | 'wrong-type'>;
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingFolderItem.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingFolderItem.ts
@@ -1,0 +1,15 @@
+import type { PRFunc } from 'freedom-async';
+import type { SyncableBundleFileMetadata, SyncableFolderMetadata, SyncableId } from 'freedom-sync-types';
+
+import type { FileSystemLocalItemMetadata } from './FileSystemLocalItemMetadata.ts';
+import type { FileSystemSyncableStoreBackingItem } from './FileSystemSyncableStoreBackingItem.ts';
+
+export interface FileSystemSyncableStoreBackingFolderItem {
+  readonly type: 'folder';
+  readonly id: SyncableId;
+  readonly metadata: PRFunc<
+    (SyncableBundleFileMetadata | SyncableFolderMetadata) & FileSystemLocalItemMetadata,
+    'not-found' | 'wrong-type'
+  >;
+  readonly contents: PRFunc<Partial<Record<SyncableId, FileSystemSyncableStoreBackingItem>>, 'not-found' | 'wrong-type'>;
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingItem.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FileSystemSyncableStoreBackingItem.ts
@@ -1,0 +1,4 @@
+import type { FileSystemSyncableStoreBackingFlatFileItem } from './FileSystemSyncableStoreBackingFlatFileItem.ts';
+import type { FileSystemSyncableStoreBackingFolderItem } from './FileSystemSyncableStoreBackingFolderItem.ts';
+
+export type FileSystemSyncableStoreBackingItem = FileSystemSyncableStoreBackingFolderItem | FileSystemSyncableStoreBackingFlatFileItem;

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FlatFileMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FlatFileMetadata.ts
@@ -1,0 +1,12 @@
+import { schema } from 'yaschema';
+
+import { fileSystemLocalItemMetadataSchema } from './FileSystemLocalItemMetadata.ts';
+import { syncableMetadataBaseSchema } from './SyncableMetadataBase.ts';
+
+export const flatFileMetadataSchema = schema.allOf3(
+  syncableMetadataBaseSchema,
+  fileSystemLocalItemMetadataSchema,
+  schema.object({
+    type: schema.string('flatFile')
+  })
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FolderMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/FolderMetadata.ts
@@ -1,0 +1,18 @@
+import { schema } from 'yaschema';
+
+import { fileSystemLocalItemMetadataSchema } from './FileSystemLocalItemMetadata.ts';
+import { syncableMetadataBaseSchema } from './SyncableMetadataBase.ts';
+
+export const folderMetadataSchema = schema.allOf3(
+  syncableMetadataBaseSchema,
+  fileSystemLocalItemMetadataSchema,
+  schema.oneOf(
+    schema.object({
+      type: schema.string('folder'),
+      encrypted: schema.boolean(true)
+    }),
+    schema.object({
+      type: schema.string('bundleFile')
+    })
+  )
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/SyncableMetadataBase.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/types/SyncableMetadataBase.ts
@@ -1,0 +1,8 @@
+import { syncableItemTypeSchema, syncableProvenanceSchema } from 'freedom-sync-types';
+import { schema } from 'yaschema';
+
+export const syncableMetadataBaseSchema = schema.object({
+  provenance: syncableProvenanceSchema,
+  type: syncableItemTypeSchema,
+  encrypted: schema.boolean()
+});

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createFile.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createFile.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import type { SyncableFlatFileMetadata, SyncableId } from 'freedom-sync-types';
+
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { createMetadataFile } from './createMetadataFile.ts';
+import { getFsPath } from './getFsPath.ts';
+
+export const createFile = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    rootPath: string,
+    ids: readonly SyncableId[],
+    data: Uint8Array,
+    metadata: SyncableFlatFileMetadata & FileSystemLocalItemMetadata
+  ): PR<undefined> => {
+    const filePath = await getFsPath(trace, rootPath, ids);
+    if (!filePath.ok) {
+      return filePath;
+    }
+
+    await fs.writeFile(filePath.value, data);
+
+    const savedMetadata = await createMetadataFile(trace, rootPath, ids, metadata);
+    if (!savedMetadata.ok) {
+      return savedMetadata;
+    }
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createFolder.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createFolder.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import type { SyncableBundleFileMetadata, SyncableFolderMetadata, SyncableId } from 'freedom-sync-types';
+
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { createMetadataFile } from './createMetadataFile.ts';
+import { getFsPath } from './getFsPath.ts';
+
+export const createFolder = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    rootPath: string,
+    ids: readonly SyncableId[],
+    metadata: (SyncableBundleFileMetadata | SyncableFolderMetadata) & FileSystemLocalItemMetadata
+  ): PR<undefined> => {
+    const dirPath = await getFsPath(trace, rootPath, ids);
+    if (!dirPath.ok) {
+      return dirPath;
+    }
+
+    await fs.mkdir(dirPath.value);
+
+    const savedMetadata = await createMetadataFile(trace, rootPath, ids, metadata);
+    if (!savedMetadata.ok) {
+      return savedMetadata;
+    }
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createMetadataFile.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/createMetadataFile.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { SyncableId } from 'freedom-sync-types';
+
+import { type AnyMetadata, anyMetadataSchema } from '../types/AnyMetadata.ts';
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { getFsPathForMetadataFile } from './getFsPathForMetadataFile.ts';
+
+export const createMetadataFile = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, rootPath: string, ids: readonly SyncableId[], metadata: AnyMetadata & FileSystemLocalItemMetadata): PR<undefined> => {
+    const filePath = await getFsPathForMetadataFile(trace, rootPath, ids);
+    if (!filePath.ok) {
+      return filePath;
+    }
+
+    const serialization = await anyMetadataSchema.serializeAsync(metadata, { validation: 'hard' });
+    if (serialization.error !== undefined) {
+      return makeFailure(new InternalSchemaValidationError(trace, { message: serialization.error }));
+    }
+
+    const outMetadataJsonString = JSON.stringify(serialization.serialized);
+    await fs.writeFile(filePath.value, outMetadataJsonString, 'utf-8');
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/deleteFileOrFolder.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/deleteFileOrFolder.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs/promises';
+
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import type { SyncableId } from 'freedom-sync-types';
+
+import { getFsPath } from './getFsPath.ts';
+
+export const deleteFileOrFolder = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, rootPath: string, ids: readonly SyncableId[]) => {
+    const fsPath = await getFsPath(trace, rootPath, ids);
+    if (!fsPath.ok) {
+      return fsPath;
+    }
+
+    await fs.rm(fsPath.value, { recursive: true });
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/generateFilenameSafeHashFromString.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/generateFilenameSafeHashFromString.ts
@@ -1,0 +1,12 @@
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { generateHashFromString } from 'freedom-crypto';
+
+export const generateFilenameSafeHashFromString = makeAsyncResultFunc([import.meta.filename], async (trace, value: string): PR<string> => {
+  const hash = await generateHashFromString(trace, { value });
+  if (!hash.ok) {
+    return hash;
+  }
+
+  return makeSuccess(Buffer.from(hash.value).toString('hex'));
+});

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/getFsPath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/getFsPath.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+
+import type { PR } from 'freedom-async';
+import { allResultsMapped, makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import type { SyncableId } from 'freedom-sync-types';
+
+import { generateFilenameSafeHashFromString } from './generateFilenameSafeHashFromString.ts';
+
+export const getFsPath = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    rootPath: string,
+    ids: readonly SyncableId[],
+    { suffixPaths = [], extension }: { suffixPaths?: string[]; extension?: string } = {}
+  ): PR<string> => {
+    const hashedIds = await allResultsMapped(trace, ids, {}, generateFilenameSafeHashFromString);
+    if (!hashedIds.ok) {
+      return hashedIds;
+    }
+
+    const fsPath = `${path.join(rootPath, ...hashedIds.value, ...suffixPaths)}${extension !== undefined ? `.${extension}` : ''}`;
+    return makeSuccess(fsPath);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/getFsPathForMetadataFile.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/getFsPathForMetadataFile.ts
@@ -1,0 +1,39 @@
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import type { SyncableId } from 'freedom-sync-types';
+
+import { generateFilenameSafeHashFromString } from './generateFilenameSafeHashFromString.ts';
+import { getFsPath } from './getFsPath.ts';
+
+export const getFsPathForMetadataFile = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, rootPath: string, ids: readonly SyncableId[]): PR<string> => {
+    const lastId = ids[ids.length - 1];
+    if (lastId === undefined) {
+      const filePath = await getFsPath(trace, rootPath, ids.slice(0, ids.length - 1), {
+        suffixPaths: ['metadata'],
+        extension: 'json'
+      });
+      if (!filePath.ok) {
+        return filePath;
+      }
+
+      return makeSuccess(filePath.value);
+    }
+
+    const hashedLastId = await generateFilenameSafeHashFromString(trace, lastId);
+    if (!hashedLastId.ok) {
+      return hashedLastId;
+    }
+
+    const filePath = await getFsPath(trace, rootPath, ids.slice(0, ids.length - 1), {
+      suffixPaths: [`metadata.${hashedLastId.value}`],
+      extension: 'json'
+    });
+    if (!filePath.ok) {
+      return filePath;
+    }
+
+    return makeSuccess(filePath.value);
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeContentsFuncForPath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeContentsFuncForPath.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { allResultsMapped, GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { NotFoundError } from 'freedom-common-errors';
+import type { SyncableId } from 'freedom-sync-types';
+import { get } from 'lodash-es';
+
+import type { FileSystemSyncableStoreBackingItem } from '../types/FileSystemSyncableStoreBackingItem.ts';
+import { getFsPath } from './getFsPath.ts';
+import { makeDataFuncForPath } from './makeDataFuncForPath.ts';
+import { makeFlatFileMetaFuncForPath } from './makeFlatFileMetaFuncForPath.ts';
+import { makeFolderMetaFuncForPath } from './makeFolderMetaFuncForPath.ts';
+import { readLocalMetadata } from './readLocalMetadata.ts';
+
+export const makeContentsFuncForPath = (rootPath: string, ids: readonly SyncableId[]) =>
+  makeAsyncResultFunc(
+    [import.meta.filename],
+    async (trace): PR<Partial<Record<SyncableId, FileSystemSyncableStoreBackingItem>>, 'not-found' | 'wrong-type'> => {
+      const dirPath = await getFsPath(trace, rootPath, ids);
+      if (!dirPath.ok) {
+        return dirPath;
+      }
+
+      try {
+        const entries = await fs.readdir(dirPath.value, { withFileTypes: true });
+
+        const result: Partial<Record<SyncableId, FileSystemSyncableStoreBackingItem>> = {};
+
+        const processedEntries = await allResultsMapped(trace, entries, {}, async (trace, entry) => {
+          if (entry.name.startsWith('metadata.') && entry.name.endsWith('.json')) {
+            return makeSuccess(undefined); // Skip local-only files
+          }
+
+          const fsPath = await getFsPath(trace, rootPath, ids, { suffixPaths: [`metadata.${entry.name}`], extension: 'json' });
+          if (!fsPath.ok) {
+            return fsPath;
+          }
+
+          const localMetadata = await readLocalMetadata(trace, fsPath.value);
+          if (!localMetadata.ok) {
+            return localMetadata;
+          }
+
+          const id = localMetadata.value.id;
+
+          if (entry.isFile()) {
+            result[id] = {
+              type: 'flatFile',
+              id,
+              metadata: makeFlatFileMetaFuncForPath(dirPath.value, [id]),
+              data: makeDataFuncForPath(dirPath.value, [id])
+            };
+          } else if (entry.isDirectory()) {
+            result[id] = {
+              type: 'folder',
+              id,
+              metadata: makeFolderMetaFuncForPath(dirPath.value, [id]),
+              contents: makeContentsFuncForPath(dirPath.value, [id])
+            };
+          }
+
+          return makeSuccess(undefined);
+        });
+        if (!processedEntries.ok) {
+          return processedEntries;
+        }
+
+        return makeSuccess(result);
+      } catch (e) {
+        if (get(e, 'code') === 'ENOENT') {
+          return makeFailure(new NotFoundError(trace, { message: `No folder found at ${dirPath.value}`, errorCode: 'not-found' }));
+        }
+
+        return makeFailure(new GeneralError(trace, e));
+      }
+    }
+  );

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeDataFuncForPath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeDataFuncForPath.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { NotFoundError } from 'freedom-common-errors';
+import type { SyncableId } from 'freedom-sync-types';
+import { get } from 'lodash-es';
+
+import { getFsPath } from './getFsPath.ts';
+
+export const makeDataFuncForPath = (rootPath: string, ids: readonly SyncableId[]) =>
+  makeAsyncResultFunc([import.meta.filename], async (trace): PR<Uint8Array, 'not-found' | 'wrong-type'> => {
+    const filePath = await getFsPath(trace, rootPath, ids);
+    if (!filePath.ok) {
+      return filePath;
+    }
+
+    try {
+      const data = await fs.readFile(filePath.value);
+      return makeSuccess(data);
+    } catch (e) {
+      if (get(e, 'code') === 'ENOENT') {
+        return makeFailure(new NotFoundError(trace, { message: `No file found at ${filePath.value}`, errorCode: 'not-found' }));
+      }
+
+      return makeFailure(new GeneralError(trace, e));
+    }
+  });

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFlatFileAccessor.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFlatFileAccessor.ts
@@ -1,0 +1,23 @@
+import { makeSuccess, makeSyncFunc } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { SyncableStoreBackingFlatFileAccessor } from 'freedom-syncable-store-types';
+
+import type { FileSystemSyncableStoreBackingFlatFileItem } from '../types/FileSystemSyncableStoreBackingFlatFileItem.ts';
+
+export const makeFlatFileAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (_trace, item: FileSystemSyncableStoreBackingFlatFileItem): SyncableStoreBackingFlatFileAccessor => {
+    return {
+      type: 'flatFile',
+      id: item.id,
+      getBinary: async (trace) => {
+        const loaded = await item.data(trace);
+        if (!loaded.ok) {
+          return generalizeFailureResult(trace, loaded, ['not-found', 'wrong-type']);
+        }
+
+        return makeSuccess(loaded.value);
+      }
+    };
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFlatFileMetaFuncForPath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFlatFileMetaFuncForPath.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import { type SyncableId, type SyncableItemMetadata } from 'freedom-sync-types';
+import type { JsonValue } from 'yaschema';
+
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { flatFileMetadataSchema } from '../types/FlatFileMetadata.ts';
+import { getFsPathForMetadataFile } from './getFsPathForMetadataFile.ts';
+
+export const makeFlatFileMetaFuncForPath = (rootPath: string, ids: readonly SyncableId[]) =>
+  makeAsyncResultFunc(
+    [import.meta.filename],
+    async (trace): PR<SyncableItemMetadata & { type: 'flatFile' } & FileSystemLocalItemMetadata, 'not-found' | 'wrong-type'> => {
+      const filePath = await getFsPathForMetadataFile(trace, rootPath, ids);
+      if (!filePath.ok) {
+        return filePath;
+      }
+
+      const metadataJsonString = await fs.readFile(filePath.value, 'utf8');
+      try {
+        const metadataJson = JSON.parse(metadataJsonString) as JsonValue;
+        const deserialization = await flatFileMetadataSchema.deserializeAsync(metadataJson, { validation: 'hard' });
+        if (deserialization.error !== undefined) {
+          return makeFailure(new InternalSchemaValidationError(trace, { message: deserialization.error }));
+        }
+
+        return makeSuccess(deserialization.deserialized);
+      } catch (e) {
+        return makeFailure(new GeneralError(trace, e));
+      }
+    }
+  );

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFolderAccessor.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFolderAccessor.ts
@@ -1,0 +1,12 @@
+import { makeSyncFunc } from 'freedom-async';
+import type { SyncableStoreBackingFolderAccessor } from 'freedom-syncable-store-types';
+
+import type { FileSystemSyncableStoreBackingFolderItem } from '../types/FileSystemSyncableStoreBackingFolderItem.ts';
+
+export const makeFolderAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (_trace, item: FileSystemSyncableStoreBackingFolderItem): SyncableStoreBackingFolderAccessor => ({
+    type: 'folder',
+    id: item.id
+  })
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFolderMetaFuncForPath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeFolderMetaFuncForPath.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { SyncableBundleFileMetadata, SyncableFolderMetadata, SyncableId } from 'freedom-sync-types';
+import type { JsonValue } from 'yaschema';
+
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { folderMetadataSchema } from '../types/FolderMetadata.ts';
+import { getFsPathForMetadataFile } from './getFsPathForMetadataFile.ts';
+
+export const makeFolderMetaFuncForPath = (rootPath: string, ids: readonly SyncableId[]) =>
+  makeAsyncResultFunc(
+    [import.meta.filename],
+    async (trace): PR<(SyncableBundleFileMetadata | SyncableFolderMetadata) & FileSystemLocalItemMetadata, 'not-found' | 'wrong-type'> => {
+      const filePath = await getFsPathForMetadataFile(trace, rootPath, ids);
+      if (!filePath.ok) {
+        return filePath;
+      }
+
+      const metadataJsonString = await fs.readFile(filePath.value, 'utf8');
+      try {
+        const metadataJson = JSON.parse(metadataJsonString) as JsonValue;
+        const deserialization = await folderMetadataSchema.deserializeAsync(metadataJson, { validation: 'hard' });
+        if (deserialization.error !== undefined) {
+          return makeFailure(new InternalSchemaValidationError(trace, { message: deserialization.error }));
+        }
+
+        return makeSuccess(deserialization.deserialized);
+      } catch (e) {
+        return makeFailure(new GeneralError(trace, e));
+      }
+    }
+  );

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeItemAccessor.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/makeItemAccessor.ts
@@ -1,0 +1,19 @@
+import { makeSyncFunc } from 'freedom-async';
+import type { SyncableStoreBackingItemAccessor } from 'freedom-syncable-store-types';
+
+import type { FileSystemSyncableStoreBackingItem } from '../types/FileSystemSyncableStoreBackingItem.ts';
+import { makeFlatFileAccessor } from './makeFlatFileAccessor.ts';
+import { makeFolderAccessor } from './makeFolderAccessor.ts';
+
+export const makeItemAccessor = makeSyncFunc(
+  [import.meta.filename],
+  (trace, item: FileSystemSyncableStoreBackingItem): SyncableStoreBackingItemAccessor => {
+    switch (item.type) {
+      case 'folder':
+        return makeFolderAccessor(trace, item);
+
+      case 'flatFile':
+        return makeFlatFileAccessor(trace, item);
+    }
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/readLocalMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/readLocalMetadata.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { JsonValue } from 'yaschema';
+
+import { anyMetadataSchema } from '../types/AnyMetadata.ts';
+import type { FileSystemLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+
+export const readLocalMetadata = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, path: string): PR<FileSystemLocalItemMetadata> => {
+    const metadataJsonString = await fs.readFile(path, 'utf-8');
+    try {
+      const metadataJson = JSON.parse(metadataJsonString) as JsonValue;
+      const deserialization = await anyMetadataSchema.deserializeAsync(metadataJson, { validation: 'hard' });
+      if (deserialization.error !== undefined) {
+        return makeFailure(new InternalSchemaValidationError(trace, { message: deserialization.error }));
+      }
+
+      const metadata = deserialization.deserialized;
+      return makeSuccess(metadata);
+    } catch (e) {
+      return makeFailure(new GeneralError(trace, e));
+    }
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/traversePath.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/traversePath.ts
@@ -1,0 +1,85 @@
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import type { SyncableId, SyncableItemType } from 'freedom-sync-types';
+import { StaticSyncablePath } from 'freedom-sync-types';
+import { guardIsExpectedType } from 'freedom-syncable-store-types';
+import type { SingleOrArray } from 'yaschema';
+
+import type { FileSystemSyncableStoreBackingItem } from '../types/FileSystemSyncableStoreBackingItem.ts';
+
+type BackingTypeBySyncableItemType<T extends SyncableItemType> =
+  | (T extends 'flatFile' ? 'flatFile' : never)
+  | (T extends 'bundleFile' ? 'folder' : never)
+  | (T extends 'folder' ? 'folder' : never);
+
+export const traversePath = makeAsyncResultFunc(
+  [import.meta.filename],
+  async <T extends SyncableItemType = SyncableItemType>(
+    trace: Trace,
+    item: FileSystemSyncableStoreBackingItem,
+    path: StaticSyncablePath,
+    expectedType?: SingleOrArray<T>
+  ): PR<
+    FileSystemSyncableStoreBackingItem & {
+      type: BackingTypeBySyncableItemType<T>;
+      metadata: FileSystemSyncableStoreBackingItem['metadata'] & { type: T };
+    },
+    'not-found' | 'wrong-type'
+  > => {
+    const idsSoFar: SyncableId[] = [];
+
+    let cursor: FileSystemSyncableStoreBackingItem = item;
+    for (const pathId of path.ids) {
+      idsSoFar.push(pathId);
+
+      switch (cursor.type) {
+        case 'flatFile':
+          return makeFailure(
+            new NotFoundError(trace, {
+              message: `Expected folder or bundleFile, found: ${cursor.type}`,
+              errorCode: 'wrong-type'
+            })
+          );
+
+        case 'folder': {
+          const contents = await cursor.contents(trace);
+          if (!contents.ok) {
+            return contents;
+          }
+
+          const nextCursor = contents.value[pathId];
+
+          if (nextCursor === undefined) {
+            return makeFailure(
+              new NotFoundError(trace, {
+                message: `No item found at ${new StaticSyncablePath(path.storageRootId, ...idsSoFar).toString()}`,
+                errorCode: 'not-found'
+              })
+            );
+          }
+
+          cursor = nextCursor;
+        }
+      }
+    }
+
+    const metadata = await cursor.metadata(trace);
+    if (!metadata.ok) {
+      return metadata;
+    }
+
+    const guards = guardIsExpectedType(trace, path, metadata.value, expectedType, 'wrong-type');
+    if (!guards.ok) {
+      return guards;
+    }
+
+    return makeSuccess(
+      cursor as FileSystemSyncableStoreBackingItem & {
+        type: BackingTypeBySyncableItemType<T>;
+        metadata: FileSystemSyncableStoreBackingItem['metadata'] & { type: T };
+      }
+    );
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/updateLocalMetadata.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/utils/updateLocalMetadata.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { SyncableId } from 'freedom-sync-types';
+import type { JsonValue } from 'yaschema';
+
+import { anyMetadataSchema } from '../types/AnyMetadata.ts';
+import type { FileSystemChangeableLocalItemMetadata } from '../types/FileSystemLocalItemMetadata.ts';
+import { getFsPathForMetadataFile } from './getFsPathForMetadataFile.ts';
+
+export const updateLocalMetadata = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    rootPath: string,
+    ids: readonly SyncableId[],
+    metadataChanges: Partial<FileSystemChangeableLocalItemMetadata>
+  ): PR<undefined> => {
+    const filePath = await getFsPathForMetadataFile(trace, rootPath, ids);
+    if (!filePath.ok) {
+      return filePath;
+    }
+
+    const metadataJsonString = await fs.readFile(filePath.value, 'utf-8');
+    try {
+      const metadataJson = JSON.parse(metadataJsonString) as JsonValue;
+      const deserialization = await anyMetadataSchema.deserializeAsync(metadataJson, { validation: 'hard' });
+      if (deserialization.error !== undefined) {
+        return makeFailure(new InternalSchemaValidationError(trace, { message: deserialization.error }));
+      }
+
+      const metadata = deserialization.deserialized;
+
+      if ('hash' in metadataChanges) {
+        metadata.hash = metadataChanges.hash;
+
+        const serialization = await anyMetadataSchema.serializeAsync(metadata, { validation: 'hard' });
+        if (serialization.error !== undefined) {
+          return makeFailure(new InternalSchemaValidationError(trace, { message: serialization.error }));
+        }
+
+        const outMetadataJsonString = JSON.stringify(serialization.serialized);
+        await fs.writeFile(filePath.value, outMetadataJsonString, 'utf-8');
+      }
+
+      return makeSuccess(undefined);
+    } catch (e) {
+      return makeFailure(new GeneralError(trace, e));
+    }
+  }
+);

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/types/FileSystemSyncableStoreBacking.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/types/FileSystemSyncableStoreBacking.ts
@@ -1,0 +1,315 @@
+import { allResultsMapped, excludeFailureResult, makeAsyncResultFunc, makeFailure, makeSuccess, type PR } from 'freedom-async';
+import { objectEntries } from 'freedom-cast';
+import { ConflictError, generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import {
+  type StaticSyncablePath,
+  type SyncableBundleFileMetadata,
+  type SyncableFlatFileMetadata,
+  type SyncableFolderMetadata,
+  type SyncableId,
+  type SyncableItemMetadata,
+  type SyncableItemType,
+  syncableItemTypes
+} from 'freedom-sync-types';
+import { isExpectedType, type SyncableStoreBacking } from 'freedom-syncable-store-types';
+import type { SyncableStoreBackingFlatFileAccessor } from 'freedom-syncable-store-types/lib/types/backing/accessors/SyncableStoreBackingFlatFileAccessor';
+import type { SyncableStoreBackingFolderAccessor } from 'freedom-syncable-store-types/lib/types/backing/accessors/SyncableStoreBackingFolderAccessor';
+import type { SyncableStoreBackingItemAccessor } from 'freedom-syncable-store-types/lib/types/backing/accessors/SyncableStoreBackingItemAccessor';
+import type { SingleOrArray } from 'yaschema';
+
+import { ROOT_FOLDER_ID } from '../internal/consts/special-ids.ts';
+import type { FileSystemLocalItemMetadata } from '../internal/types/FileSystemLocalItemMetadata.ts';
+import type { FileSystemSyncableStoreBackingFolderItem } from '../internal/types/FileSystemSyncableStoreBackingFolderItem.ts';
+import { createFile } from '../internal/utils/createFile.ts';
+import { createFolder } from '../internal/utils/createFolder.ts';
+import { createMetadataFile } from '../internal/utils/createMetadataFile.ts';
+import { deleteFileOrFolder } from '../internal/utils/deleteFileOrFolder.ts';
+import { makeContentsFuncForPath } from '../internal/utils/makeContentsFuncForPath.ts';
+import { makeFolderMetaFuncForPath } from '../internal/utils/makeFolderMetaFuncForPath.ts';
+import { makeItemAccessor } from '../internal/utils/makeItemAccessor.ts';
+import { traversePath } from '../internal/utils/traversePath.ts';
+import { updateLocalMetadata } from '../internal/utils/updateLocalMetadata.ts';
+
+export class FileSystemSyncableStoreBacking implements SyncableStoreBacking {
+  private root_: FileSystemSyncableStoreBackingFolderItem;
+  private readonly rootPath_: string;
+
+  constructor(rootPath: string) {
+    this.rootPath_ = rootPath;
+    this.root_ = {
+      type: 'folder',
+      id: ROOT_FOLDER_ID,
+      metadata: makeFolderMetaFuncForPath(this.rootPath_, []),
+      contents: makeContentsFuncForPath(this.rootPath_, [])
+    };
+  }
+
+  /** Initializes the backing for use.  This must be done exactly once for newly-created backings. */
+  public readonly initialize = makeAsyncResultFunc(
+    [import.meta.filename, 'initialize'],
+    async (trace, metadata: Omit<SyncableFolderMetadata, 'type' | 'encrypted'> & Omit<FileSystemLocalItemMetadata, 'id'>) => {
+      const savedMetadata = await createMetadataFile(trace, this.rootPath_, [], {
+        ...metadata,
+        type: 'folder' as const,
+        encrypted: true as const,
+        id: ROOT_FOLDER_ID
+      });
+      if (!savedMetadata.ok) {
+        return savedMetadata;
+      }
+
+      return makeSuccess(undefined);
+    }
+  );
+
+  public readonly existsAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'existsAtPath'],
+    async (trace, path: StaticSyncablePath): PR<boolean> => {
+      const found = await traversePath(trace, this.root_, path);
+      if (!found.ok) {
+        if (found.value.errorCode === 'not-found') {
+          return makeSuccess(false);
+        }
+
+        return generalizeFailureResult(trace, excludeFailureResult(found, 'not-found'), 'wrong-type');
+      }
+
+      return makeSuccess(found.value !== undefined);
+    }
+  );
+
+  public readonly getAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getAtPath'],
+    async <T extends SyncableItemType = SyncableItemType>(
+      trace: Trace,
+      path: StaticSyncablePath,
+      expectedType?: SingleOrArray<T>
+    ): PR<SyncableStoreBackingItemAccessor & { type: T }, 'not-found' | 'wrong-type'> => {
+      const found = await traversePath(trace, this.root_, path, expectedType);
+      if (!found.ok) {
+        return found;
+      }
+
+      const accessor = makeItemAccessor(trace, found.value);
+      return makeSuccess(accessor as SyncableStoreBackingItemAccessor & { type: T });
+    }
+  );
+
+  public readonly getIdsInPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getIdsInPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      options?: { type?: SingleOrArray<SyncableItemType> }
+    ): PR<SyncableId[], 'not-found' | 'wrong-type'> => {
+      const found = await traversePath(trace, this.root_, path, syncableItemTypes.exclude('flatFile'));
+      if (!found.ok) {
+        return found;
+      }
+
+      const contents = await found.value.contents(trace);
+      if (!contents.ok) {
+        return contents;
+      }
+
+      const ids: SyncableId[] = [];
+
+      const didFilterIds = await allResultsMapped(trace, objectEntries(contents.value), {}, async (trace, [id, item]) => {
+        if (item === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        const metadata = await item.metadata(trace);
+        if (!metadata.ok) {
+          return metadata;
+        }
+
+        const isExpected = isExpectedType(trace, metadata.value, options?.type);
+        if (isExpected.ok && isExpected.value) {
+          ids.push(id);
+        }
+
+        return makeSuccess(undefined);
+      });
+      if (!didFilterIds.ok) {
+        return didFilterIds;
+      }
+
+      return makeSuccess(ids);
+    }
+  );
+
+  public readonly getMetadataAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getMetadataAtPath'],
+    async (trace, path: StaticSyncablePath): PR<SyncableItemMetadata & FileSystemLocalItemMetadata, 'not-found' | 'wrong-type'> => {
+      if (path.ids.length === 0) {
+        return await this.root_.metadata(trace);
+      }
+
+      const id = path.lastId!;
+      const metadataById = await this.getMetadataByIdInPath(trace, path.parentPath!, new Set([id]));
+      if (!metadataById.ok) {
+        return metadataById;
+      }
+
+      if (metadataById.value[id] === undefined) {
+        return makeFailure(new NotFoundError(trace, { message: `No metadata found for ${path.toString()}`, errorCode: 'not-found' }));
+      }
+
+      return makeSuccess(metadataById.value[id]);
+    }
+  );
+
+  public readonly getMetadataByIdInPath = makeAsyncResultFunc(
+    [import.meta.filename, 'getMetadataByIdInPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      ids?: Set<SyncableId>
+    ): PR<Partial<Record<SyncableId, SyncableItemMetadata & FileSystemLocalItemMetadata>>, 'not-found' | 'wrong-type'> => {
+      const found = await traversePath(trace, this.root_, path, syncableItemTypes.exclude('flatFile'));
+      if (!found.ok) {
+        return found;
+      }
+
+      const contents = await found.value.contents(trace);
+      if (!contents.ok) {
+        return contents;
+      }
+
+      const metadataById: Partial<Record<SyncableId, SyncableItemMetadata & FileSystemLocalItemMetadata>> = {};
+      const didFilterIds = await allResultsMapped(trace, objectEntries(contents.value), {}, async (trace, [id, item]) => {
+        if (item === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        if (ids === undefined || ids.has(id)) {
+          const metadata = await item.metadata(trace);
+          if (!metadata.ok) {
+            return metadata;
+          }
+
+          metadataById[id] = metadata.value;
+        }
+
+        return makeSuccess(undefined);
+      });
+      if (!didFilterIds.ok) {
+        return didFilterIds;
+      }
+      return makeSuccess(metadataById);
+    }
+  );
+
+  public readonly createBinaryFileWithPath = makeAsyncResultFunc(
+    [import.meta.filename, 'createBinaryFileWithPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      { data, metadata }: { data: Uint8Array; metadata: SyncableFlatFileMetadata & Omit<FileSystemLocalItemMetadata, 'id'> }
+    ): PR<SyncableStoreBackingFlatFileAccessor, 'not-found' | 'wrong-type' | 'conflict'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = await traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      const contents = await foundParent.value.contents(trace);
+      if (!contents.ok) {
+        return contents;
+      }
+
+      if (contents.value[path.lastId!] !== undefined) {
+        return makeFailure(new ConflictError(trace, { message: `${path.toString()} already exists`, errorCode: 'conflict' }));
+      }
+
+      const saved = await createFile(trace, this.rootPath_, path.ids, data, { ...metadata, id: path.lastId! });
+      if (!saved.ok) {
+        return saved;
+      }
+
+      return await this.getAtPath(trace, path, 'flatFile');
+    }
+  );
+
+  public readonly createFolderWithPath = makeAsyncResultFunc(
+    [import.meta.filename, 'createFolderWithPath'],
+    async (
+      trace,
+      path: StaticSyncablePath,
+      { metadata }: { metadata: (SyncableBundleFileMetadata | SyncableFolderMetadata) & Omit<FileSystemLocalItemMetadata, 'id'> }
+    ): PR<SyncableStoreBackingFolderAccessor, 'not-found' | 'wrong-type' | 'conflict'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = await traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      const contents = await foundParent.value.contents(trace);
+      if (!contents.ok) {
+        return contents;
+      }
+
+      if (contents.value[path.lastId!] !== undefined) {
+        return makeFailure(new ConflictError(trace, { message: `${path.toString()} already exists`, errorCode: 'conflict' }));
+      }
+
+      const saved = await createFolder(trace, this.rootPath_, path.ids, { ...metadata, id: path.lastId! });
+      if (!saved.ok) {
+        return saved;
+      }
+
+      return await this.getAtPath(trace, path, syncableItemTypes.exclude('flatFile'));
+    }
+  );
+
+  public readonly deleteAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'deleteAtPath'],
+    async (trace, path: StaticSyncablePath): PR<undefined, 'not-found' | 'wrong-type'> => {
+      const parentPath = path.parentPath;
+      if (parentPath === undefined) {
+        return makeFailure(new ConflictError(trace, { message: 'Expected a parent path' }));
+      }
+
+      const foundParent = await traversePath(trace, this.root_, parentPath, syncableItemTypes.exclude('flatFile'));
+      if (!foundParent.ok) {
+        return foundParent;
+      }
+
+      const deleted = await deleteFileOrFolder(trace, this.rootPath_, path.ids);
+      if (!deleted.ok) {
+        return deleted;
+      }
+
+      return makeSuccess(undefined);
+    }
+  );
+
+  public readonly updateLocalMetadataAtPath = makeAsyncResultFunc(
+    [import.meta.filename, 'updateLocalMetadataAtPath'],
+    async (trace, path: StaticSyncablePath, metadata: Partial<FileSystemLocalItemMetadata>): PR<undefined, 'not-found' | 'wrong-type'> => {
+      const found = await traversePath(trace, this.root_, path);
+      if (!found.ok) {
+        return found;
+      }
+
+      if ('hash' in metadata) {
+        const updated = await updateLocalMetadata(trace, this.rootPath_, path.ids, { hash: metadata.hash });
+        if (!updated.ok) {
+          return updated;
+        }
+      }
+
+      return makeSuccess(undefined);
+    }
+  );
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/types/__tests__/FileSystemSyncableStoreBacking.test.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/types/__tests__/FileSystemSyncableStoreBacking.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { TestContext } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
+
+import type { Trace } from 'freedom-contexts';
+import { makeTrace } from 'freedom-contexts';
+import { generateCryptoCombinationKeySet } from 'freedom-crypto';
+import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
+import type { CryptoService } from 'freedom-crypto-service';
+import { encId, storageRootIdInfo } from 'freedom-sync-types';
+import {
+  createFolderAtPath,
+  createStringFileAtPath,
+  deleteSyncableItemAtPath,
+  generateProvenanceForNewSyncableStore,
+  getDynamicIds,
+  getFolderAtPath,
+  getMutableFolderAtPath,
+  getStringFromFileAtPath,
+  initializeRoot,
+  InMemorySyncableStore
+} from 'freedom-syncable-store-types';
+import { expectErrorCode, expectOk } from 'freedom-testing-tools';
+
+import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
+import { FileSystemSyncableStoreBacking } from '../FileSystemSyncableStoreBacking.ts';
+
+describe('FileSystemSyncableStore', () => {
+  let trace!: Trace;
+  let cryptoKeys!: PrivateCombinationCryptoKeySet;
+  let cryptoService!: CryptoService;
+  let storeBacking!: FileSystemSyncableStoreBacking;
+  let store!: InMemorySyncableStore;
+
+  const storageRootId = storageRootIdInfo.make('test');
+
+  beforeEach(async () => {
+    trace = makeTrace('test');
+
+    const internalCryptoKeys = await generateCryptoCombinationKeySet(trace);
+    expectOk(internalCryptoKeys);
+    cryptoKeys = internalCryptoKeys.value;
+
+    cryptoService = makeCryptoServiceForTesting({ cryptoKeys });
+
+    const provenance = await generateProvenanceForNewSyncableStore(trace, { storageRootId, cryptoService });
+    expectOk(provenance);
+
+    const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'testing-'));
+    console.log('rootPath', rootPath);
+
+    storeBacking = new FileSystemSyncableStoreBacking(rootPath);
+    expectOk(await storeBacking.initialize(trace, { provenance: provenance.value }));
+    store = new InMemorySyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+
+    expectOk(await initializeRoot(trace, store));
+  });
+
+  it('deleting files and folders should work', async (t: TestContext) => {
+    // Creating folder with default initial access
+    const testingFolder = await createFolderAtPath(trace, store, store.path, encId('testing'));
+    expectOk(testingFolder);
+    const testingPath = testingFolder.value.path;
+
+    // Creating file
+    const helloWorldTxtFile = await createStringFileAtPath(trace, store, testingPath, encId('hello-world.txt'), 'hello world');
+    expectOk(helloWorldTxtFile);
+    const helloWorldTxtPath = helloWorldTxtFile.value.path;
+
+    const helloWorldStringContent = await getStringFromFileAtPath(trace, store, helloWorldTxtPath);
+    expectOk(helloWorldStringContent);
+    t.assert.strictEqual(helloWorldStringContent.value, 'hello world');
+
+    // Deleting file
+    expectOk(await deleteSyncableItemAtPath(trace, store, helloWorldTxtPath));
+
+    expectErrorCode(await getStringFromFileAtPath(trace, store, helloWorldTxtPath), 'deleted');
+
+    // Deleting folder
+    expectOk(await deleteSyncableItemAtPath(trace, store, testingPath));
+
+    expectErrorCode(await getFolderAtPath(trace, store, testingPath), 'deleted');
+  });
+
+  it('getIds should work', async (t: TestContext) => {
+    // Creating folder
+    const testingFolder = await createFolderAtPath(trace, store, store.path, encId('testing'));
+    expectOk(testingFolder);
+
+    const folderIds = await getDynamicIds(trace, store, { type: 'folder' });
+    expectOk(folderIds);
+    t.assert.deepStrictEqual(folderIds.value, [encId('testing')]);
+  });
+
+  it('getFolderAtPath should work', async (_t: TestContext) => {
+    // Creating folder
+    const testingFolder = await createFolderAtPath(trace, store, store.path, encId('testing'));
+    expectOk(testingFolder);
+    const testingPath = testingFolder.value.path;
+
+    const folder = await getFolderAtPath(trace, store, testingPath);
+    expectOk(folder);
+  });
+
+  it('getMutableFolderAtPath should work', async (_t: TestContext) => {
+    // Creating folder
+    const testingFolder = await createFolderAtPath(trace, store, store.path, encId('testing'));
+    expectOk(testingFolder);
+    const testingPath = testingFolder.value.path;
+
+    const folder = await getMutableFolderAtPath(trace, store, testingPath);
+    expectOk(folder);
+  });
+});

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/types/exports.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/types/exports.ts
@@ -1,0 +1,1 @@
+export * from './FileSystemSyncableStoreBacking.ts';

--- a/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.base.json
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.base.json
@@ -1,0 +1,78 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2021",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "ES2020",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "ES2021",
+      "DOM"
+    ],        
+    /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationDir" : "./lib",
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./lib/",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src/",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "noEmit": true,
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "noErrorTruncation": true,
+
+    "resolveJsonModule": true
+  },
+  "compileOnSave": true
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.json
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [ "src", "**/__tests__", "**/__test_dependency__" ],
+  "exclude": [ "lib" ]
+}

--- a/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.mjs.json
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/tsconfig.mjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib/mjs",
+    "noEmit": false
+  },
+  "include": [ "src" ],
+  "exclude": [ "**/__tests__", "**/__test_dependency__", "lib" ]
+}


### PR DESCRIPTION
- Added `SyncableStoreBacking` type, which will be the interface for all syncable store backings
- Also added related accessor types and a `LocalItemMetadata` type, which represents the most basic metadata that will be maintained locally but not synced (e.g. the hash -- which is synced, sort of, but not via the metadata sync process)
- Added `InMemorySyncableStoreBacking`
- SyncableStore Using Generalized Backing Support
  - Implementation is still called InMemory…, which will be addressed in a subsequent commit, but the backing now controls where data is stored, whether in memory, on disk, or elsewhere
- Added server-packages/freedom-file-system-syncable-store-backing
  - This is a file system backing for Syncable Store
