### PR TITLE
Added support for salted IDs

### DIFF
--- a/code/cross-platform-packages/freedom-data-source-types/src/types/GetOrCreateSyncableStoreArgs.ts
+++ b/code/cross-platform-packages/freedom-data-source-types/src/types/GetOrCreateSyncableStoreArgs.ts
@@ -1,7 +1,8 @@
 import type { CryptoService } from 'freedom-crypto-service';
-import type { StorageRootId } from 'freedom-sync-types';
+import type { SaltId, StorageRootId } from 'freedom-sync-types';
 
 export interface GetOrCreateSyncableStoreArgs {
   storageRootId: StorageRootId;
   cryptoService: CryptoService;
+  saltsById: Partial<Record<SaltId, string>>;
 }

--- a/code/cross-platform-packages/freedom-data-source-types/src/types/InMemoryDataSources.ts
+++ b/code/cross-platform-packages/freedom-data-source-types/src/types/InMemoryDataSources.ts
@@ -1,7 +1,7 @@
 import type { PR } from 'freedom-async';
 import { makeSuccess } from 'freedom-async';
 import { Cast } from 'freedom-cast';
-import type { Trace } from 'freedom-contexts';
+import { type Trace } from 'freedom-contexts';
 import type { MutableIndexStore } from 'freedom-indexing-types';
 import { InMemoryIndexStore } from 'freedom-indexing-types';
 import type { LockStore } from 'freedom-locking-types';
@@ -58,7 +58,7 @@ export class InMemoryDataSources implements DataSources {
 
   private readonly getOrCreateSyncableStore_ = async (
     trace: Trace,
-    { storageRootId, cryptoService }: GetOrCreateSyncableStoreArgs
+    { storageRootId, cryptoService, saltsById }: GetOrCreateSyncableStoreArgs
   ): PR<MutableSyncableStore> => {
     const cacheKey = storageRootId;
     const found = this.syncableStores_[cacheKey];
@@ -73,7 +73,13 @@ export class InMemoryDataSources implements DataSources {
 
     const storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
 
-    const newStore = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    const newStore = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById
+    });
 
     this.syncableStores_[cacheKey] = newStore;
     return makeSuccess(newStore);

--- a/code/cross-platform-packages/freedom-sync-types/src/types/SyncableId.ts
+++ b/code/cross-platform-packages/freedom-sync-types/src/types/SyncableId.ts
@@ -6,8 +6,16 @@ export const syncablePlainIdInfo = makeIdInfo('._');
 export type SyncablePlainId = typeof syncablePlainIdInfo.schema.valueType;
 export const plainId = (plainId: string) => syncablePlainIdInfo.make(plainId);
 
+export const saltIdInfo = makeIdInfo('SALT_');
+export type SaltId = typeof saltIdInfo.schema.valueType;
+
+export const defaultSaltId = saltIdInfo.make('default');
+
+export const syncableSaltedIdInfo = makeIdInfo('S_');
+export type SyncableSaltedId = typeof syncableSaltedIdInfo.schema.valueType;
+
 export const syncableUuidSchema = uuidSchema;
 export type SyncableUuidId = Uuid;
 
-export const syncableIdSchema = schema.oneOf(syncablePlainIdInfo.schema, syncableUuidSchema);
+export const syncableIdSchema = schema.oneOf3(syncablePlainIdInfo.schema, syncableSaltedIdInfo.schema, syncableUuidSchema);
 export type SyncableId = typeof syncableIdSchema.valueType;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultFolderStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultFolderStore.ts
@@ -492,6 +492,11 @@ export class DefaultFolderStore implements Partial<MutableFolderStore>, FolderMa
       id: SyncableId,
       metadata: SyncableFolderMetadata & LocalItemMetadata
     ): PR<DefaultMutableSyncableFolderAccessor, 'conflict' | 'deleted'> => {
+      const store = this.weakStore_.deref();
+      if (store === undefined) {
+        return makeFailure(new InternalStateError(trace, { message: 'store was released' }));
+      }
+
       const newPath = this.path.append(id);
 
       const exists = await this.backing_.existsAtPath(trace, newPath);
@@ -512,7 +517,7 @@ export class DefaultFolderStore implements Partial<MutableFolderStore>, FolderMa
       }
 
       const folder = new DefaultMutableSyncableFolderAccessor({
-        store: this.weakStore_,
+        store,
         backing: this.backing_,
         syncTracker: this.syncTracker_,
         path: newPath

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultMutableSyncableFolderAccessor.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultMutableSyncableFolderAccessor.ts
@@ -13,7 +13,7 @@ export class DefaultMutableSyncableFolderAccessor extends DefaultMutableSyncable
     syncTracker,
     path
   }: {
-    store: WeakRef<MutableSyncableStore>;
+    store: MutableSyncableStore;
     backing: SyncableStoreBacking;
     syncTracker: SyncTracker;
     path: SyncablePath;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultMutableSyncableFolderAccessorBase.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/DefaultMutableSyncableFolderAccessorBase.ts
@@ -135,11 +135,11 @@ export abstract class DefaultMutableSyncableFolderAccessorBase implements Mutabl
     store,
     makeFolderAccessor
   }: {
-    store: WeakRef<MutableSyncableStore>;
+    store: MutableSyncableStore;
     makeFolderAccessor: (args: { path: SyncablePath }) => MutableSyncableFolderAccessor;
   }) {
-    this.weakStore_ = store;
-    this.folderOperationsHandler_ = this.makeFolderOperationsHandler_(store);
+    this.weakStore_ = new WeakRef(store);
+    this.folderOperationsHandler_ = this.makeFolderOperationsHandler_(this.weakStore_);
     this.makeFolderAccessor_ = makeFolderAccessor;
   }
 

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { encName, storageRootIdInfo } from 'freedom-sync-types';
+import { defaultSaltId, encName, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -40,7 +40,13 @@ describe('hashes', () => {
     expectOk(provenance);
 
     storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
-    store = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    store = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById: { [defaultSaltId]: makeUuid() }
+    });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
@@ -1,5 +1,6 @@
 import type { CryptoKeySetId } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import type { SaltId } from 'freedom-sync-types';
 
 import type { MutableTrustMarkStore } from './MutableTrustMarkStore.ts';
 import type { SyncableFolderAccessor } from './SyncableFolderAccessor.ts';
@@ -9,4 +10,7 @@ export interface SyncableStore extends SyncableFolderAccessor {
 
   readonly creatorCryptoKeySetId: CryptoKeySetId;
   readonly cryptoService: CryptoService;
+
+  readonly defaultSalt: string | undefined;
+  readonly saltsById: Partial<Record<SaltId, string>>;
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { encName, storageRootIdInfo } from 'freedom-sync-types';
+import { defaultSaltId, encName, storageRootIdInfo } from 'freedom-sync-types';
 import { expectErrorCode, expectIncludes, expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -43,7 +43,13 @@ describe('DefaultSyncableStore', () => {
     expectOk(provenance);
 
     storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
-    store = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    store = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById: { [defaultSaltId]: makeUuid() }
+    });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/InMemorySyncableStoreBacking.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/InMemorySyncableStoreBacking.ts
@@ -28,6 +28,10 @@ import { makeFolderAccessor } from './internal/utils/makeFolderAccessor.ts';
 import { makeItemAccessor } from './internal/utils/makeItemAccessor.ts';
 import { traversePath } from './internal/utils/traversePath.ts';
 
+export interface InMemorySyncableStoreBackingConstructorArgs {
+  metadata: Omit<SyncableFolderMetadata & LocalItemMetadata, 'name' | 'type' | 'encrypted'>;
+}
+
 export class InMemorySyncableStoreBacking implements SyncableStoreBacking {
   private readonly root_: InMemorySyncableStoreBackingFolderItem;
 

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
@@ -1,4 +1,4 @@
-import { plainId } from 'freedom-sync-types';
+import type { Uuid } from 'freedom-basic-data';
 
 /** This is only used as an internal marker */
-export const ROOT_FOLDER_ID = plainId('root');
+export const ROOT_FOLDER_ID: Uuid = '00000000-0000-0000-0000-000000000000';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
@@ -9,7 +9,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { encName, storageRootIdInfo } from 'freedom-sync-types';
+import { defaultSaltId, encName, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -43,7 +43,13 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
     expectOk(provenance);
 
     storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
-    store = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    store = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById: { [defaultSaltId]: makeUuid() }
+    });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { encName, storageRootIdInfo } from 'freedom-sync-types';
+import { defaultSaltId, encName, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 import { schema } from 'yaschema';
 
@@ -43,7 +43,13 @@ describe('createJsonFileAtPath', () => {
     expectOk(provenance);
 
     storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
-    store = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    store = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById: { [defaultSaltId]: makeUuid() }
+    });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { encName, storageRootIdInfo } from 'freedom-sync-types';
+import { defaultSaltId, encName, storageRootIdInfo } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -40,7 +40,13 @@ describe('createStringFileAtPath', () => {
     expectOk(provenance);
 
     storeBacking = new InMemorySyncableStoreBacking({ provenance: provenance.value });
-    store = new DefaultSyncableStore({ storageRootId, backing: storeBacking, cryptoService, provenance: provenance.value });
+    store = new DefaultSyncableStore({
+      storageRootId,
+      backing: storeBacking,
+      cryptoService,
+      provenance: provenance.value,
+      saltsById: { [defaultSaltId]: makeUuid() }
+    });
 
     expectOk(await initializeRoot(trace, store));
   });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/exports.ts
@@ -25,6 +25,7 @@ export * from './guards/exports.ts';
 export * from './initializeRoot.ts';
 export * from './logLs.ts';
 export * from './markSyncableNeedsRecomputeHashAtPath.ts';
+export * from './saltedId.ts';
 export * from './shouldUseTrustedTimeNamesInPath.ts';
 export * from './validation/exports.ts';
 export * from './verifyAndDecryptBinary.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/saltedId.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/saltedId.ts
@@ -1,0 +1,31 @@
+import { GeneralError } from 'freedom-async';
+import { makeTrace } from 'freedom-contexts';
+import { generateHashFromString } from 'freedom-crypto';
+import { type SyncableSaltedId, syncableSaltedIdInfo } from 'freedom-sync-types';
+
+import type { SyncableStore } from '../types/SyncableStore.ts';
+
+const trace = makeTrace(import.meta.filename);
+
+// Not using makeAsyncResultFunc here because we want this to be easily inlined for readability
+export const saltedId =
+  (plainId: string) =>
+  async (salt: SyncableStore | string | undefined): Promise<SyncableSaltedId> => {
+    if (salt === undefined) {
+      throw new GeneralError(trace, 'Salt is required');
+    }
+
+    const saltString = typeof salt === 'string' ? salt : salt.defaultSalt;
+    if (saltString === undefined) {
+      throw new GeneralError(trace, 'Salt is required');
+    }
+
+    // TODO: could probably cache these
+    const hash = await generateHashFromString(trace, { value: `${saltString}:${plainId}` });
+    if (!hash.ok) {
+      // This shouldn't really ever happen
+      throw new GeneralError(trace, hash.value);
+    }
+
+    return syncableSaltedIdInfo.make(Buffer.from(hash.value).toString('base64'));
+  };

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/consts/special-ids.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/internal/consts/special-ids.ts
@@ -1,4 +1,4 @@
-import { plainId } from 'freedom-sync-types';
+import type { Uuid } from 'freedom-basic-data';
 
 /** This is only used as an internal marker */
-export const ROOT_FOLDER_ID = plainId('root');
+export const ROOT_FOLDER_ID: Uuid = '00000000-0000-0000-0000-000000000000';


### PR DESCRIPTION
- salted IDs require a salt, which are configured when creating a SyncableStore object (can have multiple salt keys in a single store)
- without the salt, the IDs of the folders that are saltIds will be nonsense.  with the salt, they will be comprehensible