### PR TITLE
Add IDE settings, AI&Human Guides, reference code module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ coverage
 .DS_Store
 
 # IDEs
+# Root idea dir contains useful run configurations and style settings
+# If a nested dir is opened in IDE, those settings are excluded
 .idea
+!/.idea
 
 # dotenv environment variables file
 *.env*

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,15 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+
+# Freedom Ignore
+nx-*
+prettier.xml
+terraform.xml
+workspace.xml
+/inspectionProfiles/

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/freedom.iml
+++ b/.idea/freedom.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/code/.nx" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-access-control/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-crypto-data/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-crypto-service/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-crypto/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-sync-service/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-syncable-store-types/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/server-packages/freedom-fs-store/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/cross-platform-packages/freedom-object-store-types/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/backends/freedom-mail-host/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/code/deploy/workspace" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/freedom.iml" filepath="$PROJECT_DIR$/.idea/freedom.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations/_template__of_NodeJsTestRunner.xml
+++ b/.idea/runConfigurations/_template__of_NodeJsTestRunner.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="NodeJsTestRunner">
+    <node-interpreter value="project" />
+    <node-options value="--experimental-transform-types --experimental-test-module-mocks --disable-warning=ExperimentalWarning" />
+    <language value="JAVA_SCRIPT" />
+    <typescript-loader value="MANUAL_SETUP_IN_NODE_OPTION" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,6 @@
+- TS import needs .ts extension and cannot include dirs
+- Use `exports.ts` instead of `index.ts` in lib packages. Use none of them in apps and backends
+- Use `import type` for types
+- Do not change tsconfig, do not install new ts runners or builders. TS toolkit is frozen
+- Do not create d.ts files
+- If user asks to capture knowledge, add it to '## AI Knowledge' of the relevant doc. Append the section if absent

--- a/code/dev-packages/reference/README.md
+++ b/code/dev-packages/reference/README.md
@@ -1,0 +1,21 @@
+# Reference Module
+
+A simple reference module that provides string utility functions and demonstrates testing with mocking. This module is intended as a reference implementation for the Freedom project.
+
+## Features
+
+- String utility functions (capitalize, truncate)
+- Test examples using Node.js built-in test runner
+- Examples of mocking in tests
+
+## Usage
+
+```typescript
+import { capitalize, truncate } from 'freedom-reference';
+
+// Capitalize a string
+const capitalized = capitalize('hello'); // 'Hello'
+
+// Truncate a string
+const truncated = truncate('This is a long string', 10); // 'This is...'
+```

--- a/code/dev-packages/reference/package.json
+++ b/code/dev-packages/reference/package.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": {
+    "freedom-async": "0.0.0"
+  },
+  "devDependencies": {
+    "freedom-build-tools": "0.0.0",
+    "freedom-testing-tools": "0.0.0",
+    "typescript": "5.8.2"
+  },
+  "type": "module",
+  "main": "lib/mjs/exports.mjs",
+  "name": "freedom-reference",
+  "nx": {
+    "tags": [
+      "type:lib",
+      "platform:dev"
+    ]
+  },
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.mjs.json --emitDeclarationOnly && node ../../dev-packages/freedom-build-tools/lib/mjs/freedom-build.mjs --tsconfig tsconfig.mjs.json",
+    "build:dev": "FREEDOM_BUILD_MODE=DEV yarn build",
+    "build:tests": "tsc",
+    "clean": "rimraf ./coverage ./lib",
+    "depcheck": "depcheck --ignores=freedom-build-tools || (code ./package.json && exit 1)",
+    "lint": "eslint 'src/**/*.ts?(x)' --max-warnings 0",
+    "test": "yarn test:unit-tests",
+    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOG_ALLOW_BLOCKING=${FREEDOM_LOG_ALLOW_BLOCKING:-false} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:unit-tests": "NODE_OPTIONS='--experimental-transform-types --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=90000 --test",
+    "deploy:extract": "../../poc/repo/deploy.extract.sh"
+  },
+  "types": "lib/exports.d.ts",
+  "version": "0.0.0"
+}

--- a/code/dev-packages/reference/src/exports.ts
+++ b/code/dev-packages/reference/src/exports.ts
@@ -1,0 +1,10 @@
+/**
+ * Reference module exports
+ */
+
+// Export types
+export * from './types/exports.ts';
+
+// Export utils
+export * from './utils/demoMockingSubject.ts';
+export * from './utils/demoHelper.ts';

--- a/code/dev-packages/reference/src/types/exports.ts
+++ b/code/dev-packages/reference/src/types/exports.ts
@@ -1,0 +1,6 @@
+/**
+ * Type definitions for the reference module
+ */
+
+// Example type definition
+export type StringTransformer = (input: string) => string;

--- a/code/dev-packages/reference/src/utils/__tests__/demoHelper.test.ts
+++ b/code/dev-packages/reference/src/utils/__tests__/demoHelper.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+// Import the function to test
+import { demoHelper } from '../demoHelper.ts';
+
+describe('demoHelper', () => {
+  it('should create an alternative magic string', async () => {
+    // Act
+    const result = demoHelper('the-value');
+
+    // Assert
+    assert.strictEqual(result, 'the-alt-magic: the-value');
+  });
+});

--- a/code/dev-packages/reference/src/utils/__tests__/demoMockingSubject.test.ts
+++ b/code/dev-packages/reference/src/utils/__tests__/demoMockingSubject.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, mock, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+describe('demoMockingSubject', async () => {
+  // Mock dependencies and load the subject
+  const mockedDemoHelper = mock.fn(() => 'the-mocked-alt-magic');
+  mock.module('../demoHelper.ts', {
+    namedExports: {
+      demoHelper: mockedDemoHelper
+    }
+  });
+  const { demoMockingSubject } = await import('../demoMockingSubject.ts');
+
+  beforeEach(() => {
+    mockedDemoHelper.mock.resetCalls();
+  });
+
+  it('should create a magic string and use demoHelper', async () => {
+     // Act
+    const result = demoMockingSubject('the-a', 'the-b');
+
+    // Assert
+    assert.strictEqual(result, 'the-magic: the-a, the-mocked-alt-magic');
+  });
+
+  it('can illustrate mock verification', async () => {
+    // Arrange
+
+    // Act
+    demoMockingSubject('the-a', 'the-b');
+
+    // Assert
+    assert.strictEqual(mockedDemoHelper.mock.calls.length, 1);
+    assert.deepStrictEqual(mockedDemoHelper.mock.calls[0].arguments, ['the-b']);
+  });
+});

--- a/code/dev-packages/reference/src/utils/demoHelper.ts
+++ b/code/dev-packages/reference/src/utils/demoHelper.ts
@@ -1,0 +1,9 @@
+/**
+ * Creates an alternative magic string with the provided input
+ * 
+ * @param a - The input string to transform
+ * @returns The alternative magic string
+ */
+export const demoHelper = (a: string): string => {
+  return `the-alt-magic: ${a}`;
+};

--- a/code/dev-packages/reference/src/utils/demoMockingSubject.ts
+++ b/code/dev-packages/reference/src/utils/demoMockingSubject.ts
@@ -1,0 +1,12 @@
+import { demoHelper } from './demoHelper.ts';
+
+/**
+ * Creates a magic string with the provided inputs
+ *
+ * @param a - The first input string
+ * @param b - The second input string
+ * @returns The magic string
+ */
+export const demoMockingSubject = (a: string, b: string): string => {
+  return `the-magic: ${a}, ${demoHelper(b)}`;
+};

--- a/code/dev-packages/reference/tsconfig.base.json
+++ b/code/dev-packages/reference/tsconfig.base.json
@@ -1,0 +1,77 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2021",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "ES2020",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "ES2021",
+      "DOM"
+    ],        
+    /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationDir" : "./lib",
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "allowImportingTsExtensions": true,
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./lib/",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src/",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "noEmit": true,
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "noErrorTruncation": true,
+
+    "resolveJsonModule": true
+  },
+  "compileOnSave": true
+}

--- a/code/dev-packages/reference/tsconfig.json
+++ b/code/dev-packages/reference/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [ "src", "**/__tests__", "**/__test_dependency__" ],
+  "exclude": [ "lib" ]
+}

--- a/code/dev-packages/reference/tsconfig.mjs.json
+++ b/code/dev-packages/reference/tsconfig.mjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib/mjs",
+    "noEmit": false
+  },
+  "include": [ "src" ],
+  "exclude": [ "**/__tests__", "**/__test_dependency__", "lib" ]
+}

--- a/docs/.obsidian/.gitignore
+++ b/docs/.obsidian/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitignore
+
+# These settings are important for consistency and to follow our standards
+!app.json
+
+# Not adding other config files to git
+# Recommended plugins:
+#   Obsidian Smart Typography - https://github.com/mgmeyers/obsidian-smart-typography

--- a/docs/.obsidian/app.json
+++ b/docs/.obsidian/app.json
@@ -1,0 +1,10 @@
+{
+  "alwaysUpdateLinks": true,
+  "newFileLocation": "current",
+  "useMarkdownLinks": true,
+  "showUnsupportedFiles": true,
+  "attachmentFolderPath": "./assets",
+  "newLinkFormat": "relative",
+  "useTab": false,
+  "showInlineTitle": false
+}

--- a/docs/Architecture/App Structure.md
+++ b/docs/Architecture/App Structure.md
@@ -1,0 +1,159 @@
+# App Structure
+
+This document outlines the standard structure for applications in the Freedom project.
+
+## Overview
+
+Freedom applications follow a modular architecture pattern that emphasizes separation of concerns, maintainability, and code reuse. Each application is organized into modules that encapsulate specific functionality.
+
+## Directory Structure
+
+```
+app/
+├── src/
+│   ├── main.ts                  # Main entry point
+│   ├── config.ts                # Configuration and environment variables
+│   ├── types/                   # TypeScript type definitions
+│   │   ├── exports.ts           # Exports all type definitions
+│   │   └── ...                  # Type definition files
+│   ├── modules/                 # Functional modules
+│   │   ├── module-name/         # A specific module
+│   │   │   ├── index.ts         # Exports from the module
+│   │   │   └── utils/           # Utility functions for the module
+│   │   │       ├── function1.ts # One function per file
+│   │   │       └── function2.ts # Another function
+│   │   └── ...                  # Other modules
+│   ├── utils/                   # Shared utility functions
+│   └── tasks/                   # Background tasks
+├── package.json                 # Dependencies and scripts
+├── tsconfig.json                # TypeScript configuration
+└── README.md                    # Documentation
+```
+
+## Modules
+
+The `modules/` directory contains the core functionality of the application, organized by domain or feature. Each module should:
+
+1. Be self-contained with minimal dependencies on other modules
+2. Have a clear, single responsibility
+3. Export its functionality through an `index.ts` file
+4. Implement functions in individual files within a `utils/` directory
+
+### Common Module Types
+
+1. **HTTP Server Module**: Handles HTTP requests and responses
+   - Example: `modules/http-server/`
+   - Functions: `createServer.ts`, `startServer.ts`
+
+2. **Data Processing Module**: Processes and transforms data
+   - Example: `modules/email-encoder/`
+   - Functions: `processEmail.ts`, `extractEmailAddress.ts`
+
+3. **Storage Module**: Manages data persistence
+   - Example: `modules/storage/`
+   - Functions: `loadUsers.ts`, `saveToStorage.ts`, `getBucket.ts`
+
+## Function Files
+
+Each function should be defined in its own file within the module's `utils/` directory. Function files should:
+
+1. Have a clear, descriptive name that matches the function name
+2. Export a single function as the default export
+3. Include proper JSDoc comments
+4. Be focused on a single responsibility
+
+Example:
+```typescript
+/**
+ * Extract email address from a string that might be in the format "Name <email@example.com>"
+ */
+
+export function extractEmailAddress(addressString: string | undefined): string {
+  if (!addressString) {
+    return '';
+  }
+  
+  // Check if the address is in the format "Name <email@example.com>"
+  const match = addressString.match(/<([^>]+)>/);
+  if (match && match[1]) {
+    return match[1].toLowerCase();
+  }
+  
+  // Otherwise, return the original string
+  return addressString.toLowerCase();
+}
+```
+
+## Configuration
+
+Application configuration should be centralized in a `config.ts` file that:
+
+1. Exports individual configuration values (not grouped in objects)
+2. Handles environment variable parsing and defaults
+3. Includes descriptive comments for each configuration value
+
+Example:
+```typescript
+/**
+ * Server configuration
+ */
+
+/** Port to run the server on */
+export const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+
+/** Host to bind the server to */
+export const HOST = '0.0.0.0';
+
+/**
+ * Storage configuration
+ */
+
+/** Google Cloud Storage bucket for storing emails and user data */
+export const APP_BUCKET = process.env.APP_BUCKET || 'user-files-dev-abd0971d';
+
+/** Path to the users database file */
+export const USERS_FILE = 'users.json';
+```
+
+## Types
+
+Type definitions should be organized in the `types/` directory and exported through `types/exports.ts`. Each type should:
+
+1. Have a clear, descriptive name
+2. Include proper JSDoc comments
+3. Be focused on a specific data structure
+
+## Testing
+
+Tests are organized in `__tests__` directories adjacent to the code being tested:
+
+- Each module should have tests for its public API
+- Tests should be located in a `__tests__` directory within the same directory as the code being tested
+- Test files should be named with the `.test.ts` extension
+- Use the Node.js built-in test runner with `describe` and `it` blocks
+- Helper functions for testing can be placed in a `__test_dependency__` directory at the module root
+
+Example test structure:
+```
+src/
+├── types/
+│   ├── __tests__/
+│   │   └── SomeType.test.ts
+│   └── SomeType.ts
+├── utils/
+│   ├── __tests__/
+│   │   └── someUtil.test.ts
+│   └── someUtil.ts
+└── __test_dependency__/
+    └── testHelpers.ts
+```
+
+Use [Tests](Tests.md) guide to write the test files.
+
+## Best Practices
+
+1. **Imports**: Import configurations as a namespace: `import * as config from '../../config'`
+2. **Exports**: Use named exports rather than default exports
+3. **Function Size**: Keep functions small and focused on a single task
+4. **Dependencies**: Minimize dependencies between modules
+5. **Documentation**: Include JSDoc comments for all functions and types

--- a/docs/Architecture/Module Structure.md
+++ b/docs/Architecture/Module Structure.md
@@ -1,0 +1,84 @@
+# Module Structure
+
+Each module in the Freedom project follows a consistent structure to maintain organization and clarity. This document outlines the purpose of each folder and file within a module.
+
+## Root Directory
+
+The root directory of a module contains configuration files and the main source code:
+
+- `package.json`: Defines the module's dependencies, scripts, and metadata
+- `tsconfig.json`: TypeScript configuration for the module
+- `tsconfig.base.json`: Base TypeScript configuration that's extended by other configs
+- `tsconfig.mjs.json`: TypeScript configuration for ES modules
+
+## Folders
+
+### src/
+
+The `src/` directory contains all the source code for the module:
+
+- `exports.ts`: Main entry point that re-exports all public APIs
+- `types/`: Contains TypeScript type definitions and interfaces
+  - `exports.ts`: Exports all type definitions
+- `utils/`: Utility functions and helpers
+- `impl/`: Implementation of the module's functionality
+
+### lib/
+
+The `lib/` directory contains the compiled output of the TypeScript code:
+
+- Generated during the build process
+- Should not be committed to version control
+
+### node_modules/
+
+The `node_modules/` directory contains all the dependencies installed for the module:
+
+- Generated during package installation
+- Should not be committed to version control
+
+## Testing
+
+Tests are organized in `__tests__` directories adjacent to the code being tested:
+
+- Each module should have tests for its public API
+- Tests should be located in a `__tests__` directory within the same directory as the code being tested
+- Test files should be named with the `.test.ts` extension
+- Use the Node.js built-in test runner with `describe` and `it` blocks
+- Helper functions for testing can be placed in a `__test_dependency__` directory at the module root
+
+Example test structure:
+```
+src/
+├── types/
+│   ├── __tests__/
+│   │   └── SomeType.test.ts
+│   └── SomeType.ts
+├── utils/
+│   ├── __tests__/
+│   │   └── someUtil.test.ts
+│   └── someUtil.ts
+└── __test_dependency__/
+    └── testHelpers.ts
+```
+
+Use [Tests](Tests.md) guide to write the test files.
+## Module Types
+
+The project contains several types of modules:
+
+1. **Cross-Platform Packages**: Located in `code/cross-platform-packages/`
+   - Used by both server and client applications
+   - Typically contain core functionality and types
+
+2. **Server Packages**: Located in `code/server-packages/`
+   - Used exclusively by server applications
+   - Typically contain server-specific functionality
+
+3. **Development Packages**: Located in `code/dev-packages/`
+   - Used during development and testing
+   - Typically contain build tools and testing utilities
+
+4. **Applications**: Located in `code/apps/`
+   - Complete applications built using the other packages
+   - Typically have additional configuration for deployment

--- a/docs/Architecture/Tests.md
+++ b/docs/Architecture/Tests.md
@@ -1,0 +1,69 @@
+# Tests Writing Standard
+
+## File organization
+
+Follow [Module Structure](Module%20Structure.md) or [App Structure](App%20Structure.md) according to the module type.
+
+## Reference code
+
+Use [demoMockingSubject.test.ts](../../code/dev-packages/reference/src/utils/__tests__/demoMockingSubject.test.ts) as a comprehensive reference. If anything is missing there that you’ve done — update the reference.
+
+## Principles
+
+### AAA Pattern for Test Cases
+
+All test cases must follow the AAA (Arrange-Act-Assert) pattern:
+
+1. **Arrange**: Set up the test conditions (initialize objects, prepare data, mock dependencies)
+2. **Act**: Execute the action being tested (call the function or method)
+3. **Assert**: Verify the expected outcomes (check return values, state changes, or interactions)
+
+In long scenarios iteration of block is acceptable.
+
+**NB:** Do not write long scenarios out of laziness, use them only to document a complete process (i.e. as a better specification, not simply a test).
+
+| Typical | Extra Arrange is OK |
+| ------- | ------------------- |
+| Arrange | Arrange             |
+| Act     | Act                 |
+| Assert  | Assert              |
+| Act     | Arrange             |
+| Assert  | Act                 |
+| Act     | Assert              |
+| Assert  |                     |
+### Coverage
+
+Source coverage metrics are implemented. Functional coverage process is yet to be defined.
+
+Always wrap with `describe` block and use `async` functions for `it`. Make `it` part of the sentence that continues in the string literal.
+
+```ts
+describe('makeTheWorldHappier', () => {
+  it('makes the world 3..7% happier', async () => {
+     // Arrange
+     ...
+  });
+
+  ...
+});
+```
+
+*AI direction.* Always **start creating a test file** with a single test for a typical scenario. Always use this test name literally. User should approve and ask for more explicitly.
+
+```ts
+describe('subjectFunction', () => {
+  it('handles a typical case', async () => {
+     // Arrange
+     ...
+  });
+
+  // Another test case idea 1 (list ideas, do not write the actual test at first)
+  // Another test case idea 2
+  // ...
+});
+```
+
+## AI Knowledge
+
+- Run single test file: `yarn test /Users/...test.ts`
+- Fixture file path making: `path.resolve(import.meta.dirname, 'fixtures/file.json')`

--- a/docs/Processes/New Module.md
+++ b/docs/Processes/New Module.md
@@ -1,0 +1,34 @@
+# Creating a New Module
+
+## Generic Module Files
+
+Do this step by step. Use `code/cross-platform-packages/freedom-syncable-store-types` as a reference module.
+
+- [ ] Create the module directory in the appropriate location (`code/cross-platform-packages/`, `code/server-packages/`, etc.)
+- [ ] Copy as is the following files from the reference module:
+  - [ ] `package.json`
+  - [ ] `tsconfig.json`
+  - [ ] `tsconfig.base.json`
+  - [ ] `tsconfig.mjs.json`
+- [ ] Adjust `package.json` for the new module
+- [ ] Create the basic directory structure:
+  - [ ] `src/`
+  - [ ] `src/types/`
+  - [ ] `src/types/__tests__`
+- [ ] Create the following files:
+  - [ ] `src/exports.ts`
+  - [ ] `src/types/exports.ts`
+- [ ] Create `README.md`, fill it with reasonable description of the module, if you have one. One short paragraph with the purpose.
+- [ ] Add the module to `code/freedom-email.code-workspace` in the "folders" array
+
+## Custom Implementation
+
+Refer to [Module Structure](../Architecture/Module%20Structure.md) for a detailed explanation of each folder's purpose.
+
+Remember to follow the project's coding standards and patterns when implementing your module.
+
+## AI Agent Memory
+
+- Use shell commands to copy
+- Never edit tsconfig files, only copy them
+- Follow the order. Never write the custom code until the generic section steps are all completed


### PR DESCRIPTION
@brianwestphal see these commits.

The main focus is `docs/Processes/New Module.md` - the process is always a sort of pain. So here I'm adding everything AI will need. The root file is for Windsurf, but the docs are for any agent as well as for humans.

IDE settings for WebStorm and Obsidian are only essential to make them produce compatible texts. Plus run configuration for tests.
