### PR TITLE
DEV build mode support for overriding environment variables (primarily for web)

### DIFF
--- a/code/cross-platform-packages/freedom-contexts/src/utils/__tests__/getEnv.test.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/utils/__tests__/getEnv.test.ts
@@ -1,0 +1,30 @@
+import type { TestContext } from 'node:test';
+import { describe, it } from 'node:test';
+
+import { devMakeEnvDerivative, devOnEnvChange, devSetEnv, getEnv } from '../getEnv.ts';
+
+describe('getEnv', () => {
+  it('should work', (t: TestContext) => {
+    t.assert.strictEqual(getEnv('SOME_ENV_VALUE', process.env.SOME_ENV_VALUE), undefined);
+
+    const derived = devMakeEnvDerivative('SOME_ENV_VALUE', 'my-testing-value', (envValue) => (arg: number) => {
+      return `hello:${envValue ?? 'nothing'}:${arg + 1}`;
+    });
+
+    let calledOnEnvChange = 0;
+    devOnEnvChange('SOME_ENV_VALUE', 'my-testing-value', () => {
+      console.trace('CALLED');
+      calledOnEnvChange += 1;
+    });
+
+    t.assert.strictEqual(calledOnEnvChange, 1);
+    t.assert.strictEqual(derived(1), 'hello:my-testing-value:2');
+
+    devSetEnv('SOME_ENV_VALUE', 'my-other-testing-value');
+
+    t.assert.strictEqual(calledOnEnvChange, 2);
+    t.assert.strictEqual(getEnv('SOME_ENV_VALUE', process.env.SOME_ENV_VALUE), 'my-other-testing-value');
+
+    t.assert.strictEqual(derived(2), 'hello:my-other-testing-value:3');
+  });
+});

--- a/code/cross-platform-packages/freedom-contexts/src/utils/getEnv.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/utils/getEnv.ts
@@ -1,7 +1,95 @@
+import type { TypeOrPromisedType } from 'yaschema';
+
+const globalEnvOverrides: Partial<Record<string, string>> = {};
+const globalEnvVersions: Partial<Record<string, number>> = {};
+const globalOnEnvChange: Partial<Record<string, Array<() => TypeOrPromisedType<void>>>> = {};
+
 export const getEnv = (name: string, defaultValue: string | undefined): string | undefined => {
+  DEV: if (globalEnvOverrides[name] !== undefined) {
+    return globalEnvOverrides[name];
+  }
+
   try {
     return process.env[name] ?? defaultValue;
   } catch (_e) {
     return defaultValue;
   }
 };
+
+/**
+ * In DEV build mode, this sets an override for the specified environment variable
+ *
+ * In PROD build mode, this does nothing
+ */
+export const devSetEnv = (name: string, value: string | undefined) => {
+  DEV: {
+    if (globalEnvOverrides[name] === value) {
+      return; // Nothing to do
+    }
+
+    globalEnvOverrides[name] = value;
+    globalEnvVersions[name] = (globalEnvVersions[name] ?? 0) + 1;
+
+    const triggerFuncs = [...(globalOnEnvChange[name] ?? [])];
+    for (const func of triggerFuncs) {
+      func();
+    }
+  }
+};
+
+/**
+ * In DEV build mode, makes a function that is updated anytime the environment is changed using `devSetEnv`.
+ *
+ * In PROD build mode, the resulting functions always uses the initial environment value.
+ */
+export let devMakeEnvDerivative = <ArgsT extends any[], ReturnT>(
+  name: string,
+  defaultValue: string | undefined,
+  func: (value: string | undefined) => (...args: ArgsT) => ReturnT
+): ((...args: ArgsT) => ReturnT) => func(getEnv(name, defaultValue));
+
+// Replacing devMakeEnvDerivative in DEV build mode
+DEV: {
+  devMakeEnvDerivative = <ArgsT extends any[], ReturnT>(
+    name: string,
+    defaultValue: string | undefined,
+    func: (value: string | undefined) => (...args: ArgsT) => ReturnT
+  ): ((...args: ArgsT) => ReturnT) => {
+    let lastVersion = globalEnvVersions[name] ?? 0;
+    let cached = func(getEnv(name, defaultValue));
+
+    return (...args: ArgsT): ReturnT => {
+      const nextVersion = globalEnvVersions[name] ?? 0;
+      if (nextVersion === lastVersion) {
+        return cached(...args);
+      }
+
+      lastVersion = nextVersion;
+      cached = func(getEnv(name, defaultValue));
+      return cached(...args);
+    };
+  };
+}
+
+/**
+ * In DEV build mode, registers a global callback that is run any time the environment is changed using `devSetEnv`
+ *
+ * In PROD build mode, the callback is run once with the initial environment value.
+ */
+export let devOnEnvChange = (
+  name: string,
+  defaultValue: string | undefined,
+  func: (value: string | undefined) => TypeOrPromisedType<void>
+): TypeOrPromisedType<void> => func(getEnv(name, defaultValue));
+
+// Replacing devOnEnvChange in DEV build mode
+DEV: {
+  devOnEnvChange = (name, defaultValue, func) => {
+    const update = () => func(getEnv(name, defaultValue));
+
+    globalOnEnvChange[name] = globalOnEnvChange[name] ?? [];
+    globalOnEnvChange[name].push(update);
+
+    update();
+  };
+}


### PR DESCRIPTION
- Use devSetEnv to override an environment variable
- Use devMakeEnvDerivative to make a function that generates a new function if the environment variable changes
- Use devOnEnvChange to get a callback if an environment variable changes