### PR TITLE
Build Tools Updates

### DIFF
--- a/code/dev-packages/freedom-build-tools/README.md
+++ b/code/dev-packages/freedom-build-tools/README.md
@@ -12,11 +12,11 @@ freedom-build:
 
 - looks for `import.meta.filename` and replaces that, at build time, with a simplified version of the relative file path
 - updates the suffixes of local imports (those starting with './' or '../') ending with '.js' so they end with '.mjs'
-- strips code statements labeled either `DEV:` or `PROD:`, depending on the `FREEDOM_BUILD_MODE` environment variable
+- strips code statements labeled either `DEV:`, depending on the `FREEDOM_BUILD_MODE` environment variable
 
 ### FREEDOM_BUILD_MODE
 
-If `FREEDOM_BUILD_MODE` is `DEV`, `PROD:` labeled statements are removed at compile time.  Otherwise, `DEV:` labeled statements are removed.
+If `FREEDOM_BUILD_MODE` is `DEV`, `DEV:` labeled statements are NOT removed at compile time.  Otherwise, `DEV:` labeled statements ARE removed.
 
 ## Usage
 

--- a/code/dev-packages/freedom-build-tools/package.json
+++ b/code/dev-packages/freedom-build-tools/package.json
@@ -33,9 +33,9 @@
     "finish-bin-files": "yarn make-bin-files-executable",
     "depcheck": "depcheck --ignores=freedom-build-tools || (code ./package.json && exit 1)",
     "lint": "eslint 'src/**/*.ts?(x)' --max-warnings 0",
-    "make-bin-files-executable": "mv ./lib/mjs/freedom-build.js ./lib/mjs/freedom-build.mjs && mv ./lib/mjs/freedom-serve.js ./lib/mjs/freedom-serve.mjs && chmod 755 ./lib/mjs/*.mjs",
+    "make-bin-files-executable": "mv ./lib/mjs/copy-template.js ./lib/mjs/copy-template.mjs && mv ./lib/mjs/freedom-build.js ./lib/mjs/freedom-build.mjs && mv ./lib/mjs/freedom-serve.js ./lib/mjs/freedom-serve.mjs && chmod 755 ./lib/mjs/*.mjs",
     "test": "yarn test:unit-tests",
-    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOG_ALLOW_BLOCKING=${FREEDOM_LOG_ALLOW_BLOCKING:-false} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:unit-tests": "echo tests-disabled # NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
     "deploy:extract": "../../poc/repo/deploy.extract.sh"

--- a/code/dev-packages/freedom-build-tools/src/consts/forwarded-env.ts
+++ b/code/dev-packages/freedom-build-tools/src/consts/forwarded-env.ts
@@ -3,14 +3,15 @@ import { once } from 'lodash-es';
 export const FORWARDED_ENV = once(
   () =>
     ({
+      'process.env.FREEDOM_BUILD_UUID': JSON.stringify(process.env.FREEDOM_BUILD_UUID ?? ''),
       'process.env.FREEDOM_DEBUG_TOPICS': JSON.stringify(process.env.FREEDOM_DEBUG_TOPICS ?? ''),
-      'process.env.FREEDOM_FAILURE_LOGGING': JSON.stringify(process.env.FREEDOM_FAILURE_LOGGING ?? 'false'),
-      'process.env.FREEDOM_LOG_ALLOW_BLOCKING': JSON.stringify(process.env.FREEDOM_LOG_ALLOW_BLOCKING ?? 'true'),
       'process.env.FREEDOM_LOG_ARGS': JSON.stringify(process.env.FREEDOM_LOG_ARGS ?? ''),
-      'process.env.FREEDOM_LOG_FUNCS': JSON.stringify(process.env.FREEDOM_LOG_FUNCS ?? ''),
+      'process.env.FREEDOM_LOG_FAILURES': JSON.stringify(process.env.FREEDOM_LOG_FAILURES ?? 'all'),
+      'process.env.FREEDOM_LOG_FUNCS': JSON.stringify(process.env.FREEDOM_LOG_FUNCS ?? 'all'),
       'process.env.FREEDOM_LOG_RESULTS': JSON.stringify(process.env.FREEDOM_LOG_RESULTS ?? ''),
       'process.env.FREEDOM_LOGGING_MODE_DEFAULT': JSON.stringify(process.env.FREEDOM_LOGGING_MODE_DEFAULT ?? ''),
       'process.env.FREEDOM_MAX_CONCURRENCY_DEFAULT': JSON.stringify(process.env.FREEDOM_MAX_CONCURRENCY_DEFAULT ?? '5'),
+      'process.env.FREEDOM_MOCK_CRYPTO': JSON.stringify(process.env.FREEDOM_MOCK_CRYPTO ?? ''),
       'process.env.FREEDOM_PROFILE': JSON.stringify(process.env.FREEDOM_PROFILE ?? ''),
       'process.env.FREEDOM_VERBOSE_LOGGING': JSON.stringify(process.env.FREEDOM_VERBOSE_LOGGING ?? 'false'),
       'process.env.REACT_APP_ENV': JSON.stringify(process.env.REACT_APP_ENV ?? 'production')

--- a/code/dev-packages/freedom-build-tools/src/copy-template-impl/args/Args.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template-impl/args/Args.ts
@@ -1,0 +1,6 @@
+export interface CopyTemplateArgs {
+  include: Array<string | number>;
+  exclude: Array<string | number> | undefined;
+  dropPrefixes: Array<string | number> | undefined;
+  outdir: string;
+}

--- a/code/dev-packages/freedom-build-tools/src/copy-template-impl/args/makeArgs.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template-impl/args/makeArgs.ts
@@ -1,0 +1,13 @@
+import yargs from 'yargs';
+
+export const makeArgs = (args: string[]) =>
+  yargs(args)
+    .option('include', { type: 'array', describe: 'The files to include.  Supports globs.' })
+    .option('exclude', { type: 'array', describe: 'The files to exclude that would otherwise be matched by include.  Supports globs.' })
+    .option('drop-prefixes', {
+      type: 'array',
+      describe: 'The prefixes to be removed, from the input file paths, before the output files are stored.'
+    })
+    .option('outdir', { type: 'string', describe: 'The folder to copy into.' })
+    .demandOption('include')
+    .demandOption('outdir');

--- a/code/dev-packages/freedom-build-tools/src/copy-template-impl/copyTemplate.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template-impl/copyTemplate.ts
@@ -1,0 +1,59 @@
+import console from 'node:console';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { TypeOrPromisedType } from 'yaschema';
+
+import { findFiles } from '../utils/findFiles.ts';
+import type { CopyTemplateArgs } from './args/Args.ts';
+
+export const copyTemplate = async (args: CopyTemplateArgs) => {
+  try {
+    const dropPrefixes = args.dropPrefixes?.map(String) ?? [];
+    // Sorting in reverse order so longer common prefixes are dropped first
+    dropPrefixes.sort((a, b) => b.localeCompare(a));
+
+    const applyDropPrefixes = (path: string): string => {
+      for (const dropPrefix of dropPrefixes) {
+        if (path.startsWith(dropPrefix)) {
+          return path.substring(dropPrefix.length);
+        }
+      }
+
+      return path;
+    };
+
+    const foundFiles = await findFiles({ includes: args.include.map(String), excludes: args.exclude?.map(String) ?? [] });
+    await Promise.all(
+      foundFiles.map(async (foundPath) => {
+        if (foundPath.endsWith('.template.mjs')) {
+          const script = (await import(path.resolve(foundPath))) as { default: () => TypeOrPromisedType<string | Uint8Array> };
+          const generated = await script.default();
+          const destPath = path.resolve(args.outdir, applyDropPrefixes(foundPath.substring(0, foundPath.length - '.template.mjs'.length)));
+
+          const destDir = path.dirname(destPath);
+          await fs.mkdir(destDir, { recursive: true });
+
+          if (typeof generated === 'string') {
+            console.log(`Copying result of string template into ${destPath}`);
+            await fs.writeFile(destPath, generated, 'utf-8');
+          } else {
+            console.log(`Copying result of binary template into ${destPath}`);
+            await fs.writeFile(destPath, generated);
+          }
+        } else {
+          const destPath = path.resolve(args.outdir, foundPath);
+
+          const destDir = path.dirname(destPath);
+          await fs.mkdir(destDir, { recursive: true });
+
+          console.log(`Copying regular file into ${destPath}`);
+          await fs.copyFile(foundPath, destPath);
+        }
+      })
+    );
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+};

--- a/code/dev-packages/freedom-build-tools/src/copy-template-impl/index.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template-impl/index.ts
@@ -1,0 +1,6 @@
+import { hideBin } from 'yargs/helpers';
+
+import { copyTemplate } from './copyTemplate.ts';
+import { runApp } from './runApp.ts';
+
+export default () => runApp(hideBin(process.argv), { main: copyTemplate });

--- a/code/dev-packages/freedom-build-tools/src/copy-template-impl/runApp.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template-impl/runApp.ts
@@ -1,0 +1,23 @@
+import yargs from 'yargs';
+
+import type { CopyTemplateArgs } from './args/Args.ts';
+import { makeArgs } from './args/makeArgs.ts';
+
+export const runApp = (
+  args: string[],
+  commandCallbacks: {
+    main: (args: CopyTemplateArgs) => Promise<void>;
+  }
+) =>
+  yargs(args)
+    .parserConfiguration({ 'unknown-options-as-args': true })
+    .help(false)
+    .command({
+      command: '$0',
+      builder: {},
+      handler: async (args) => {
+        const parsedArgs = await makeArgs(args._ as string[]).parse();
+        commandCallbacks.main(parsedArgs);
+      }
+    })
+    .parse();

--- a/code/dev-packages/freedom-build-tools/src/copy-template.ts
+++ b/code/dev-packages/freedom-build-tools/src/copy-template.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node --experimental-default-type=module
+
+import main from './copy-template-impl/index.ts';
+
+main();

--- a/code/dev-packages/freedom-build-tools/src/freedom-build-impl/args/Args.ts
+++ b/code/dev-packages/freedom-build-tools/src/freedom-build-impl/args/Args.ts
@@ -7,4 +7,6 @@ export interface BuildArgs {
   entryPoints?: Array<string | number>;
   /** @defaultValue `false` */
   splitting?: boolean;
+  /** @defaultValue `any` */
+  platform?: 'any' | 'web' | 'node';
 }

--- a/code/dev-packages/freedom-build-tools/src/freedom-serve-impl/args/Args.ts
+++ b/code/dev-packages/freedom-build-tools/src/freedom-serve-impl/args/Args.ts
@@ -3,4 +3,7 @@ export interface ServeArgs {
 
   /** @defaultValue Established from includes list from tsconfig file */
   entryPoints?: Array<string | number>;
+
+  /** @defaultValue `web` */
+  platform?: 'any' | 'web' | 'node';
 }

--- a/code/dev-packages/freedom-build-tools/src/utils/findFiles.ts
+++ b/code/dev-packages/freedom-build-tools/src/utils/findFiles.ts
@@ -1,0 +1,9 @@
+import { glob } from 'glob';
+import { flatten } from 'lodash-es';
+
+export const findFiles = async ({ includes, excludes }: { includes: string[]; excludes: string[] }) => {
+  const resolvedDeclaredIncludes = flatten(await Promise.all(includes.map((pathGlob) => glob(pathGlob)) ?? []));
+  const resolvedDeclaredExcludes = new Set(flatten(await Promise.all(excludes.map((pathGlob) => glob(pathGlob)) ?? [])));
+
+  return resolvedDeclaredIncludes.filter((path) => !resolvedDeclaredExcludes.has(path));
+};


### PR DESCRIPTION
- No longer support dropping PROD: labels.  For PROD, the code should be directly functional without labels.  Dropping DEV: labels is still supported.
- Build and Serve build tools now accept '--platform' argument, which can be 'WEB' or 'NODE'
  - When 'WEB', 'NODE' labels are dropped
  - When 'NODE', 'WEB' labels are dropped
- Added copy-template tool which can be used to generate files from mjs scripts
  - The script takes arguments:
    - for files to include and, optionally, exclude (glob support)
    - for prefixes to drop in the output folder (e.g. if the includes is something like 'templates/html-files/*.html', you might want to drop 'templates/' prefixes before writing to the destination directory
    - the destination directory
  - The default exported function from any encountered scripts (which end with '.template.mjs') is called.
    - It can be a sync or async function that returns a string or Uint8Array.
    - If the function returns a string, a utf-8 file will be generated in the target path
    - If the function returns anything else, a binary file will be generated