### PR TITLE
Added FREEDOM_LOG_FAILURES environment variable

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -16,13 +16,13 @@ yarn test
 | Name | Description |
 | --- | --- |
 | FREEDOM_BUILD_MODE | Set to `DEV` to enable compile-time development features, guarded with DEV labels.  `yarn prep:dev` implies this.  Use `yarn clean` when switching build modes |
-| FREEDOM_LOG_FUNCS | (DEV build mode only) Default = `all`.  See Log Rules below. |
+| FREEDOM_BUILD_UUID | A string value that will be replaced at build time. |
+| FREEDOM_LOG_FUNCS | (DEV build mode only) Functions to log start and completion marker lines for.  Default = `all`.  See Log Rules below. |
 | FREEDOM_LOG_ARGS | For any functions logged due to `FREEDOM_LOG_FUNCS`, determines if argument values should be logged as well. See Log Rules below. |
+| FREEDOM_LOG_FAILURES | (DEV build mode only) For any functions not logged due to `FREEDOM_LOG_FUNCS`, determine if failures should be logged.  Default = `all`.  See Log Rules below. |
 | FREEDOM_LOG_RESULTS | For any functions logged due to `FREEDOM_LOG_FUNCS`, determines if results should be logged as well. See Log Rules below. |
 | FREEDOM_DEBUG_TOPICS | (DEV build mode only) A comma / newline set of topics to log.  See `debugTopic` function in `freedom-async` package.  A logger must be setup for this to work, ex. using `FREEDOM_VERBOSE_LOGGING=true`. |
-| FREEDOM_VERBOSE_LOGGING | (DEV build mode only) Set to `true` to enable default logging automatically -- intended to be used for debugging tests.  This also implies `FREEDOM_FAILURE_LOGGING=true`.  In production, logging is normally configured using code instead. |
-| FREEDOM_FAILURE_LOGGING | (DEV build mode only) Set to `true` to enable default logging for test failures. |
-| FREEDOM_LOG_ALLOW_BLOCKING | Default = `true`.  If `false`, wrapped logs are sent to the error logged. |
+| FREEDOM_VERBOSE_LOGGING | (DEV build mode only) Set to `true` to enable default logging automatically -- intended to be used for debugging tests.  In production, logging is normally configured using code instead. |
 | FREEDOM_PROFILE | (DEV build mode only) Set to enable profiling.  Follows the same rules as Log Rules. |
 | FREEDOM_MAX_CONCURRENCY_DEFAULT | If unset, the default value is `5`.  When debugging tests, it's helpful to set this to `1` to make logs easier to follow. |
 | FREEDOM_LOGGING_MODE_DEFAULT | If unset, the default value is `structured`.  When debugging tests or running locally, it's sometimes easier to read flat logs, which can be done using the value: `flat`. |

--- a/code/cross-platform-packages/freedom-async/src/internal/debugging/funcs.ts
+++ b/code/cross-platform-packages/freedom-async/src/internal/debugging/funcs.ts
@@ -1,11 +1,17 @@
 /* node:coverage disable */
 
-import { getEnv, type Trace } from 'freedom-contexts';
+import { devMakeEnvDerivative, type Trace } from 'freedom-contexts';
 
 import { makeShouldIncludeTraceForDebuggingFunc } from './makeShouldIncludeTraceForDebuggingFunc.ts';
 
 export let shouldLogFunc: (trace: Trace) => boolean = () => false;
+export let shouldLogFailures: (trace: Trace) => boolean = () => false;
 
 DEV: {
-  shouldLogFunc = makeShouldIncludeTraceForDebuggingFunc(getEnv('FREEDOM_LOG_FUNCS', process.env.FREEDOM_LOG_FUNCS) ?? 'all');
+  shouldLogFunc = devMakeEnvDerivative('FREEDOM_LOG_FUNCS', process.env.FREEDOM_LOG_FUNCS, (envValue) =>
+    makeShouldIncludeTraceForDebuggingFunc(envValue ?? 'all')
+  );
+  shouldLogFailures = devMakeEnvDerivative('FREEDOM_LOG_FAILURES', process.env.FREEDOM_LOG_FAILURES, (envValue) =>
+    makeShouldIncludeTraceForDebuggingFunc(envValue ?? 'all')
+  );
 }

--- a/code/cross-platform-packages/freedom-async/src/utils/callSyncFunc.ts
+++ b/code/cross-platform-packages/freedom-async/src/utils/callSyncFunc.ts
@@ -10,7 +10,7 @@ import { trackMetrics } from '../config/metrics.ts';
 import { ONE_SEC_MSEC } from '../internal/consts/time.ts';
 import { argsToStrings, shouldLogFuncArgs } from '../internal/debugging/args.ts';
 import { getCallCount } from '../internal/debugging/callCounter.ts';
-import { shouldLogFunc } from '../internal/debugging/funcs.ts';
+import { shouldLogFailures, shouldLogFunc } from '../internal/debugging/funcs.ts';
 import { resultToString, shouldLogFuncResult } from '../internal/debugging/results.ts';
 import type { FuncOptions } from '../types/FuncOptions.ts';
 
@@ -46,12 +46,15 @@ export const callSyncFunc = <ArgsT extends any[], ReturnT>(
   let errorCode: 'generic' | undefined;
   const stackTop = once(() => getTraceStackTop(trace));
   let shouldLogForDev = false;
+  let shouldLogFailuresForDev = false;
   try {
     DEV: {
       /* node:coverage disable */
       if (shouldLogFunc(trace)) {
         shouldLogForDev = true;
         log().debug?.(trace, 'Starting', stackTop(), `(call#${callCount})`, ...(shouldLogFuncArgs(trace) ? argsToStrings(args) : []));
+      } else if (shouldLogFailures(trace)) {
+        shouldLogFailuresForDev = true;
       }
       /* node:coverage enable */
     }
@@ -95,7 +98,7 @@ export const callSyncFunc = <ArgsT extends any[], ReturnT>(
 
     DEV: {
       /* node:coverage disable */
-      if (shouldLogForDev) {
+      if (shouldLogForDev || (errorCode !== undefined && shouldLogFailuresForDev)) {
         log().debug?.(
           trace,
           `Completed (call#${callCount})`,


### PR DESCRIPTION
- default is `all`
- can be used when FREEDOM_LOG_FUNCS doesn't select a function, to log only if there's a failure, so it's often nice to use `FREEDOM_VERBOSE_LOGGING=true FREEDOM_LOG_FUNCS=`, which will configure logging but only log failures and all function calls