### PR TITLE
Added FREEDOM_MOCK_CRYPTO environment variable

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -21,6 +21,7 @@ yarn test
 | FREEDOM_LOG_ARGS | For any functions logged due to `FREEDOM_LOG_FUNCS`, determines if argument values should be logged as well. See Log Rules below. |
 | FREEDOM_LOG_FAILURES | (DEV build mode only) For any functions not logged due to `FREEDOM_LOG_FUNCS`, determine if failures should be logged.  Default = `all`.  See Log Rules below. |
 | FREEDOM_LOG_RESULTS | For any functions logged due to `FREEDOM_LOG_FUNCS`, determines if results should be logged as well. See Log Rules below. |
+| FREEDOM_MOCK_CRYPTO | (DEB build mode only) Set to `true` to cause crypto and hashing related functions to leave content as readable as possible. |
 | FREEDOM_DEBUG_TOPICS | (DEV build mode only) A comma / newline set of topics to log.  See `debugTopic` function in `freedom-async` package.  A logger must be setup for this to work, ex. using `FREEDOM_VERBOSE_LOGGING=true`. |
 | FREEDOM_VERBOSE_LOGGING | (DEV build mode only) Set to `true` to enable default logging automatically -- intended to be used for debugging tests.  In production, logging is normally configured using code instead. |
 | FREEDOM_PROFILE | (DEV build mode only) Set to enable profiling.  Follows the same rules as Log Rules. |

--- a/code/cross-platform-packages/freedom-crypto/package.json
+++ b/code/cross-platform-packages/freedom-crypto/package.json
@@ -33,7 +33,7 @@
     "depcheck": "depcheck --ignores=freedom-build-tools || (code ./package.json && exit 1)",
     "lint": "eslint 'src/**/*.ts?(x)' --max-warnings 0",
     "test": "yarn test:unit-tests",
-    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOG_ALLOW_BLOCKING=${FREEDOM_LOG_ALLOW_BLOCKING:-false} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
+    "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:unit-tests": "NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
     "deploy:extract": "../../poc/repo/deploy.extract.sh"

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/bufferFromBufferSource.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/bufferFromBufferSource.ts
@@ -1,0 +1,7 @@
+export const bufferFromBufferSource = (bufferSource: BufferSource): Buffer => {
+  if (ArrayBuffer.isView(bufferSource)) {
+    return Buffer.from(bufferSource.buffer, bufferSource.byteOffset, bufferSource.byteLength);
+  }
+
+  return Buffer.from(bufferSource);
+};

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/decrypt.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/decrypt.ts
@@ -1,0 +1,27 @@
+import { getEnv } from 'freedom-contexts';
+
+import { bufferFromBufferSource } from './bufferFromBufferSource.ts';
+
+export let decrypt = async (
+  algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams,
+  key: CryptoKey,
+  data: BufferSource
+): Promise<ArrayBuffer> => await crypto.subtle.decrypt(algorithm, key, data);
+
+// Replacing decrypt in DEV build mode
+DEV: {
+  decrypt = async (algorithm, key, data) => {
+    if (getEnv('FREEDOM_MOCK_CRYPTO', process.env.FREEDOM_MOCK_CRYPTO) === 'true') {
+      const dataBuffer = bufferFromBufferSource(data);
+
+      const mockPrefixBuffer = Buffer.from('MOCK_ENCRYPTED_', 'utf-8');
+      if (dataBuffer.subarray(0, mockPrefixBuffer.byteLength).equals(mockPrefixBuffer)) {
+        return dataBuffer.subarray(mockPrefixBuffer.byteLength);
+      } else {
+        return await crypto.subtle.decrypt(algorithm, key, data);
+      }
+    } else {
+      return await crypto.subtle.decrypt(algorithm, key, data);
+    }
+  };
+}

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/digest.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/digest.ts
@@ -1,0 +1,30 @@
+import { getEnv } from 'freedom-contexts';
+
+import { bufferFromBufferSource } from './bufferFromBufferSource.ts';
+
+export let digest = async (algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer> =>
+  await crypto.subtle.digest(algorithm, data);
+
+// Replacing digest in DEV build mode
+DEV: {
+  digest = async (algorithm, data) => {
+    if (getEnv('FREEDOM_MOCK_CRYPTO', process.env.FREEDOM_MOCK_CRYPTO) === 'true') {
+      const dataBuffer = bufferFromBufferSource(data).subarray(0, 16);
+
+      const actualDigest = await crypto.subtle.digest(algorithm, data);
+
+      const outBuffer = new Uint8Array(actualDigest.byteLength + dataBuffer.byteLength);
+
+      let offset = 0;
+      outBuffer.set(Buffer.from(actualDigest), offset);
+      offset += actualDigest.byteLength;
+
+      outBuffer.set(dataBuffer, offset);
+      offset += dataBuffer.byteLength;
+
+      return outBuffer;
+    } else {
+      return await crypto.subtle.digest(algorithm, data);
+    }
+  };
+}

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/encrypt.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/encrypt.ts
@@ -1,0 +1,32 @@
+import { getEnv } from 'freedom-contexts';
+
+import { bufferFromBufferSource } from './bufferFromBufferSource.ts';
+
+export let encrypt = async (
+  algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams,
+  key: CryptoKey,
+  data: BufferSource
+): Promise<ArrayBuffer> => await crypto.subtle.encrypt(algorithm, key, data);
+
+// Replacing encrypt in DEV build mode
+DEV: {
+  encrypt = async (algorithm, key, data) => {
+    if (getEnv('FREEDOM_MOCK_CRYPTO', process.env.FREEDOM_MOCK_CRYPTO) === 'true') {
+      const dataBuffer = bufferFromBufferSource(data);
+
+      const mockPrefixBuffer = Buffer.from('MOCK_ENCRYPTED_', 'utf-8');
+      const outBuffer = new Uint8Array(mockPrefixBuffer.byteLength + dataBuffer.byteLength);
+
+      let offset = 0;
+      outBuffer.set(mockPrefixBuffer, offset);
+      offset += mockPrefixBuffer.byteLength;
+
+      outBuffer.set(dataBuffer, offset);
+      offset += dataBuffer.byteLength;
+
+      return outBuffer;
+    } else {
+      return await crypto.subtle.encrypt(algorithm, key, data);
+    }
+  };
+}

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/sign.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/sign.ts
@@ -1,0 +1,20 @@
+import { getEnv } from 'freedom-contexts';
+import type { CryptoKeySetId } from 'freedom-crypto-data';
+
+export let sign = async (
+  _cryptoKeySetId: CryptoKeySetId,
+  algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+  key: CryptoKey,
+  data: BufferSource
+): Promise<ArrayBuffer> => await crypto.subtle.sign(algorithm, key, data);
+
+// Replacing sign in DEV build mode
+DEV: {
+  sign = async (cryptoKeySetId, algorithm, key, data): Promise<ArrayBuffer> => {
+    if (getEnv('FREEDOM_MOCK_CRYPTO', process.env.FREEDOM_MOCK_CRYPTO) === 'true') {
+      return Buffer.from(`MOCK_SIGNATURE_${cryptoKeySetId}`, 'utf-8');
+    } else {
+      return await crypto.subtle.sign(algorithm, key, data);
+    }
+  };
+}

--- a/code/cross-platform-packages/freedom-crypto/src/internal/utils/verify.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/internal/utils/verify.ts
@@ -1,0 +1,26 @@
+import { getEnv } from 'freedom-contexts';
+import type { CryptoKeySetId } from 'freedom-crypto-data';
+
+import { bufferFromBufferSource } from './bufferFromBufferSource.ts';
+
+export let verify = async (
+  _cryptoKeySetId: CryptoKeySetId,
+  algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+  key: CryptoKey,
+  signature: BufferSource,
+  data: BufferSource
+): Promise<boolean> => await crypto.subtle.verify(algorithm, key, signature, data);
+
+// Replacing verify in DEV build mode
+DEV: {
+  verify = async (cryptoKeySetId, algorithm, key, signature, data) => {
+    if (getEnv('FREEDOM_MOCK_CRYPTO', process.env.FREEDOM_MOCK_CRYPTO) === 'true') {
+      const signatureBuffer = bufferFromBufferSource(signature);
+
+      const expectedMockValue = Buffer.from(`MOCK_SIGNATURE_${cryptoKeySetId}`, 'utf-8');
+      return signatureBuffer.equals(expectedMockValue);
+    } else {
+      return await crypto.subtle.verify(algorithm, key, signature, data);
+    }
+  };
+}

--- a/code/cross-platform-packages/freedom-crypto/src/utils/decrypting/decryptBuffer.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/utils/decrypting/decryptBuffer.ts
@@ -7,6 +7,7 @@ import type { DecryptingKeySet } from 'freedom-crypto-data';
 import { asymmetricalAlgorithmByEncryptionMode, symmetricalAlgorithmByEncryptionMode } from 'freedom-crypto-data';
 
 import { encryptionModesByIntValue } from '../../internal/consts/encryption-mode-integers.ts';
+import { decrypt } from '../../internal/utils/decrypt.ts';
 
 export const decryptBuffer = makeAsyncResultFunc(
   [import.meta.filename],
@@ -59,7 +60,7 @@ export const decryptBuffer = makeAsyncResultFunc(
 
             const encryptedString = encryptedValue.slice(offset);
 
-            const decryptedString = await crypto.subtle.decrypt(
+            const decryptedString = await decrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               decryptingKeys.forDecrypting.rsaPrivateKey,
               encryptedString
@@ -98,13 +99,13 @@ export const decryptBuffer = makeAsyncResultFunc(
 
             const encryptedString = encryptedValue.slice(offset);
 
-            const decryptedIv = await crypto.subtle.decrypt(
+            const decryptedIv = await decrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               decryptingKeys.forDecrypting.rsaPrivateKey,
               encryptedIv
             );
 
-            const decryptedAesKey = await crypto.subtle.decrypt(
+            const decryptedAesKey = await decrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               decryptingKeys.forDecrypting.rsaPrivateKey,
               encryptedAesKey
@@ -118,7 +119,7 @@ export const decryptBuffer = makeAsyncResultFunc(
               ['decrypt']
             );
 
-            const decryptedString = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: decryptedIv }, aesKey, encryptedString);
+            const decryptedString = await decrypt({ name: 'AES-GCM', iv: decryptedIv }, aesKey, encryptedString);
 
             return makeSuccess(Buffer.from(decryptedString));
           } else {

--- a/code/cross-platform-packages/freedom-crypto/src/utils/encrypting/encryptBuffer.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/utils/encrypting/encryptBuffer.ts
@@ -6,6 +6,7 @@ import { asymmetricalAlgorithmByEncryptionMode, preferredEncryptionMode } from '
 
 import { intValuesByEncryptionMode } from '../../internal/consts/encryption-mode-integers.ts';
 import { MAX_RSA_OAEP_4096_PAYLOAD_LENGTH_BYTES } from '../../internal/consts/limits.ts';
+import { encrypt } from '../../internal/utils/encrypt.ts';
 
 export const encryptBuffer = makeAsyncResultFunc(
   [import.meta.filename],
@@ -28,7 +29,7 @@ export const encryptBuffer = makeAsyncResultFunc(
           if (singleStageMode) {
             // Single stage mode is used for encrypting short messages, using RSA encryption directly
 
-            const encryptedString = await crypto.subtle.encrypt(
+            const encryptedString = await encrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               encryptingKeys.forEncrypting.rsaPublicKey,
               value
@@ -76,7 +77,7 @@ export const encryptBuffer = makeAsyncResultFunc(
             // Two-stage mode is used for longer messages where the actual message body is encrypted with AES
 
             const iv = await encryptingKeys.forEncrypting.getNextIv();
-            const encryptedIv = await crypto.subtle.encrypt(
+            const encryptedIv = await encrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               encryptingKeys.forEncrypting.rsaPublicKey,
               iv
@@ -84,13 +85,13 @@ export const encryptBuffer = makeAsyncResultFunc(
 
             const { raw: rawAesKey, native: aesKey } = await encryptingKeys.forEncrypting.getRawAesKey();
 
-            const encryptedAesKey = await crypto.subtle.encrypt(
+            const encryptedAesKey = await encrypt(
               asymmetricalAlgorithmByEncryptionMode['RSA-OAEP/4096/SHA-256'],
               encryptingKeys.forEncrypting.rsaPublicKey,
               rawAesKey
             );
 
-            const encryptedString = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, value);
+            const encryptedString = await encrypt({ name: 'AES-GCM', iv }, aesKey, value);
 
             /**
              * Format:

--- a/code/cross-platform-packages/freedom-crypto/src/utils/signing/generateSignatureForBuffer.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/utils/signing/generateSignatureForBuffer.ts
@@ -5,6 +5,7 @@ import type { SigningKeySet, SigningMode } from 'freedom-crypto-data';
 import { algorithmBySigningMode, preferredSigningMode } from 'freedom-crypto-data';
 
 import { intValuesBySigningMode } from '../../internal/consts/signing-mode-integers.ts';
+import { sign } from '../../internal/utils/sign.ts';
 
 export const generateSignatureForBuffer = makeAsyncResultFunc(
   [import.meta.filename],
@@ -23,7 +24,7 @@ export const generateSignatureForBuffer = makeAsyncResultFunc(
       switch (mode) {
         case 'RSASSA-PKCS1-v1_5/4096/SHA-256': {
           const signature = Buffer.from(
-            await crypto.subtle.sign(algorithmBySigningMode[mode], signingKeys.forSigning.rsaPrivateKey, value)
+            await sign(signingKeys.id, algorithmBySigningMode[mode], signingKeys.forSigning.rsaPrivateKey, value)
           );
 
           /**

--- a/code/cross-platform-packages/freedom-crypto/src/utils/validation/isSignatureValidForBuffer.ts
+++ b/code/cross-platform-packages/freedom-crypto/src/utils/validation/isSignatureValidForBuffer.ts
@@ -5,6 +5,7 @@ import type { SigningMode, VerifyingKeySet } from 'freedom-crypto-data';
 import { algorithmBySigningMode } from 'freedom-crypto-data';
 
 import { signingModesByIntValue } from '../../internal/consts/signing-mode-integers.ts';
+import { verify } from '../../internal/utils/verify.ts';
 
 export const isSignatureValidForBuffer = makeAsyncResultFunc(
   [import.meta.filename],
@@ -35,7 +36,8 @@ export const isSignatureValidForBuffer = makeAsyncResultFunc(
       switch (mode) {
         case 'RSASSA-PKCS1-v1_5/4096/SHA-256': {
           const rawSignature = signature.slice(offset);
-          const isValid = await crypto.subtle.verify(
+          const isValid = await verify(
+            verifyingKeys.id,
             algorithmBySigningMode[mode],
             verifyingKeys.forVerifying.rsaPublicKey,
             rawSignature,


### PR DESCRIPTION
- Can be set to true (DEV build only) to replace encrypt, decrypt, sign, verify, and digest with functions that leave the content readable (but mark it so it's clear its been processed)