### PR TITLE
Syncable Types Updates

### DIFF
--- a/code/cross-platform-packages/freedom-access-control-types/package.json
+++ b/code/cross-platform-packages/freedom-access-control-types/package.json
@@ -7,6 +7,8 @@
     "freedom-conflict-free-document-data": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-crypto-data": "0.0.0",
+    "freedom-serialization": "0.0.0",
+    "freedom-trusted-time-source": "0.0.0",
     "yaschema": "4.4.2"
   },
   "devDependencies": {

--- a/code/cross-platform-packages/freedom-access-control-types/src/types/AddAccessChange.ts
+++ b/code/cross-platform-packages/freedom-access-control-types/src/types/AddAccessChange.ts
@@ -1,5 +1,5 @@
-import type { CryptoKeySetId } from 'freedom-crypto-data';
-import { cryptoKeySetIdInfo, makeEncryptedValueSchema } from 'freedom-crypto-data';
+import type { CombinationCryptoKeySet } from 'freedom-crypto-data';
+import { combinationCryptoKeySetSchema, cryptoKeySetIdInfo, makeEncryptedValueSchema } from 'freedom-crypto-data';
 import type { Schema } from 'yaschema';
 import { schema } from 'yaschema';
 
@@ -8,12 +8,12 @@ import { sharedSecretKeysSchema } from './SharedSecretKeys.ts';
 export const makeAddAccessChangeParamsSchema = <RoleT extends string>({ roleSchema }: { roleSchema: Schema<RoleT> }) =>
   schema.object<AddAccessChangeParams<RoleT>, 'no-infer'>({
     type: schema.string('add-access'),
-    publicKeyId: cryptoKeySetIdInfo.schema,
+    publicKeys: combinationCryptoKeySetSchema,
     role: roleSchema
   });
 export interface AddAccessChangeParams<RoleT extends string> {
   type: 'add-access';
-  publicKeyId: CryptoKeySetId;
+  publicKeys: CombinationCryptoKeySet;
   role: RoleT;
 }
 

--- a/code/cross-platform-packages/freedom-access-control-types/src/types/InitialAccess.ts
+++ b/code/cross-platform-packages/freedom-access-control-types/src/types/InitialAccess.ts
@@ -1,9 +1,11 @@
-import type { SignedValue } from 'freedom-crypto-data';
+import type { SerializedValue } from 'freedom-basic-data';
+import type { CombinationCryptoKeySet, CryptoKeySetId, SignedValue } from 'freedom-crypto-data';
 
 import type { AccessControlState } from './AccessControlState.ts';
 import type { SharedKeys } from './SharedKeys.ts';
 
 export interface InitialAccess<RoleT extends string> {
-  state: SignedValue<AccessControlState<RoleT>>;
+  state: SignedValue<SerializedValue<AccessControlState<RoleT>>>;
+  publicKeysById: SignedValue<SerializedValue<Partial<Record<CryptoKeySetId, CombinationCryptoKeySet>>>>;
   sharedKeys: SharedKeys[];
 }

--- a/code/cross-platform-packages/freedom-access-control-types/src/types/TrustedTimeSignedAccessChange.ts
+++ b/code/cross-platform-packages/freedom-access-control-types/src/types/TrustedTimeSignedAccessChange.ts
@@ -1,0 +1,10 @@
+import type { SerializedValue } from 'freedom-basic-data';
+import type { SignedValue } from 'freedom-crypto-data';
+import type { TrustedTime } from 'freedom-trusted-time-source';
+
+import type { TimedAccessChange } from './TimedAccessChange.ts';
+
+export interface TrustedTimeSignedAccessChange<RoleT extends string> {
+  trustedTime: TrustedTime;
+  signedAccessChange: SignedValue<SerializedValue<TimedAccessChange<RoleT>>>;
+}

--- a/code/cross-platform-packages/freedom-access-control-types/src/types/exports.ts
+++ b/code/cross-platform-packages/freedom-access-control-types/src/types/exports.ts
@@ -9,3 +9,4 @@ export * from './SharedKeys.ts';
 export * from './SharedPublicKeys.ts';
 export * from './SharedSecretKeys.ts';
 export * from './TimedAccessChange.ts';
+export * from './TrustedTimeSignedAccessChange.ts';

--- a/code/cross-platform-packages/freedom-access-control/package.json
+++ b/code/cross-platform-packages/freedom-access-control/package.json
@@ -9,6 +9,7 @@
     "freedom-crypto": "0.0.0",
     "freedom-crypto-data": "0.0.0",
     "freedom-crypto-service": "0.0.0",
+    "freedom-serialization": "0.0.0",
     "freedom-trusted-time-source": "0.0.0",
     "yaschema": "4.4.2"
   },

--- a/code/cross-platform-packages/freedom-crypto-data/src/types/PublicKeysById.ts
+++ b/code/cross-platform-packages/freedom-crypto-data/src/types/PublicKeysById.ts
@@ -1,0 +1,7 @@
+import { schema } from 'yaschema';
+
+import { combinationCryptoKeySetSchema } from './crypto-key-sets/combinationCryptoKeySetSchema.ts';
+import { cryptoKeySetIdInfo } from './CryptoKeySetId.ts';
+
+export const publicKeysByIdSchema = schema.record(cryptoKeySetIdInfo.schema, combinationCryptoKeySetSchema);
+export type PublicKeysById = typeof publicKeysByIdSchema.valueType;

--- a/code/cross-platform-packages/freedom-crypto-data/src/types/exports.ts
+++ b/code/cross-platform-packages/freedom-crypto-data/src/types/exports.ts
@@ -6,6 +6,7 @@ export * from './EncryptionMode.ts';
 export * from './HashingMode.ts';
 export * from './PlainOrEncryptedValue.ts';
 export * from './PrivatePem.ts';
+export * from './PublicKeysById.ts';
 export * from './PublicPem.ts';
 export * from './PureCryptoKeySet.ts';
 export * from './PureDecryptingKeySet.ts';

--- a/code/cross-platform-packages/freedom-crypto-service/src/types/CryptoService.ts
+++ b/code/cross-platform-packages/freedom-crypto-service/src/types/CryptoService.ts
@@ -1,12 +1,9 @@
 import type { PRFunc } from 'freedom-async';
-import type { CryptoKeySetId, DecryptingKeySet, EncryptingKeySet, SigningKeySet, VerifyingKeySet } from 'freedom-crypto-data';
+import type { CombinationCryptoKeySet, CryptoKeySetId, PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 
 export interface CryptoService {
+  readonly getPrivateCryptoKeySet: PRFunc<PrivateCombinationCryptoKeySet, 'not-found', [id?: CryptoKeySetId]>;
   readonly getPrivateCryptoKeySetIds: PRFunc<CryptoKeySetId[]>;
-
-  readonly getEncryptingKeySetForId: PRFunc<EncryptingKeySet, 'not-found', [id: CryptoKeySetId]>;
-  readonly getVerifyingKeySetForId: PRFunc<VerifyingKeySet, 'not-found', [id: CryptoKeySetId]>;
-
-  readonly getSigningKeySet: PRFunc<SigningKeySet, 'not-found', [id?: CryptoKeySetId]>;
-  readonly getDecryptingKeySet: PRFunc<DecryptingKeySet, 'not-found', [id?: CryptoKeySetId]>;
+  // TODO: see if we can remove this
+  readonly getPublicCryptoKeySetForId: PRFunc<CombinationCryptoKeySet, 'not-found', [id: CryptoKeySetId]>;
 }

--- a/code/cross-platform-packages/freedom-crypto-service/src/utils/decryptOneEncryptedValue.ts
+++ b/code/cross-platform-packages/freedom-crypto-service/src/utils/decryptOneEncryptedValue.ts
@@ -30,11 +30,11 @@ export const decryptOneEncryptedValue = makeAsyncResultFunc(
 
     const encryptedValue = encryptedValues[keyId]!;
 
-    const decryptingKeys = await cryptoService.getDecryptingKeySet(trace, keyId);
-    if (!decryptingKeys.ok) {
-      return generalizeFailureResult(trace, decryptingKeys, 'not-found');
+    const privateKeys = await cryptoService.getPrivateCryptoKeySet(trace, keyId);
+    if (!privateKeys.ok) {
+      return generalizeFailureResult(trace, privateKeys, 'not-found');
     }
 
-    return await decryptEncryptedValue(trace, encryptedValue, { decryptingKeys: decryptingKeys.value });
+    return await decryptEncryptedValue(trace, encryptedValue, { decryptingKeys: privateKeys.value });
   }
 );

--- a/code/cross-platform-packages/freedom-crypto-service/src/utils/makeCryptoService.ts
+++ b/code/cross-platform-packages/freedom-crypto-service/src/utils/makeCryptoService.ts
@@ -1,14 +1,6 @@
 import type { PR, PRFunc } from 'freedom-async';
 import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
-import type {
-  CombinationCryptoKeySet,
-  CryptoKeySetId,
-  DecryptingKeySet,
-  EncryptingKeySet,
-  PrivateCombinationCryptoKeySet,
-  SigningKeySet,
-  VerifyingKeySet
-} from 'freedom-crypto-data';
+import type { CombinationCryptoKeySet, CryptoKeySetId, PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 
 import type { CryptoService } from '../types/CryptoService.ts';
 
@@ -25,51 +17,27 @@ export const makeCryptoService = ({
 }): CryptoService => ({
   getPrivateCryptoKeySetIds,
 
-  getEncryptingKeySetForId: makeAsyncResultFunc(
-    [import.meta.filename, 'getEncryptingKeySetForId'],
-    async (trace, id: CryptoKeySetId): PR<EncryptingKeySet, 'not-found'> => {
-      const cryptoKeys = await getPublicCryptoKeysById(trace, id);
-      if (!cryptoKeys.ok) {
-        return cryptoKeys;
-      }
-
-      return makeSuccess(cryptoKeys.value.forEncrypting);
-    }
-  ),
-
-  getVerifyingKeySetForId: makeAsyncResultFunc(
-    [import.meta.filename, 'getVerifyingKeySetForId'],
-    async (trace, id: CryptoKeySetId): PR<VerifyingKeySet, 'not-found'> => {
-      const cryptoKeys = await getPublicCryptoKeysById(trace, id);
-      if (!cryptoKeys.ok) {
-        return cryptoKeys;
-      }
-
-      return makeSuccess(cryptoKeys.value.forVerifying);
-    }
-  ),
-
-  getSigningKeySet: makeAsyncResultFunc(
-    [import.meta.filename, 'getSigningKeySet'],
-    async (trace, id?: CryptoKeySetId): PR<SigningKeySet, 'not-found'> => {
+  getPrivateCryptoKeySet: makeAsyncResultFunc(
+    [import.meta.filename, 'getPrivateKeySet'],
+    async (trace, id?: CryptoKeySetId): PR<PrivateCombinationCryptoKeySet, 'not-found'> => {
       const cryptoKeys = await (id !== undefined ? getPrivateCryptoKeysById(trace, id) : getMostRecentPrivateCryptoKeys(trace));
       if (!cryptoKeys.ok) {
         return cryptoKeys;
       }
 
-      return makeSuccess(cryptoKeys.value.forSigning);
+      return makeSuccess(cryptoKeys.value);
     }
   ),
 
-  getDecryptingKeySet: makeAsyncResultFunc(
-    [import.meta.filename, 'getDecryptingKeySet'],
-    async (trace, id?: CryptoKeySetId): PR<DecryptingKeySet, 'not-found'> => {
-      const cryptoKeys = await (id !== undefined ? getPrivateCryptoKeysById(trace, id) : getMostRecentPrivateCryptoKeys(trace));
+  getPublicCryptoKeySetForId: makeAsyncResultFunc(
+    [import.meta.filename, 'getPublicKeySetForId'],
+    async (trace, id: CryptoKeySetId): PR<CombinationCryptoKeySet, 'not-found'> => {
+      const cryptoKeys = await getPublicCryptoKeysById(trace, id);
       if (!cryptoKeys.ok) {
         return cryptoKeys;
       }
 
-      return makeSuccess(cryptoKeys.value.forDecrypting);
+      return makeSuccess(cryptoKeys.value);
     }
   )
 });

--- a/code/cross-platform-packages/freedom-logging-types/src/internal/utils/getEnv.ts
+++ b/code/cross-platform-packages/freedom-logging-types/src/internal/utils/getEnv.ts
@@ -1,7 +1,0 @@
-export const getEnv = (name: string, defaultValue: string | undefined): string | undefined => {
-  try {
-    return process.env[name];
-  } catch (_e) {
-    return defaultValue;
-  }
-};

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/attachSyncServiceToSyncableStore.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/attachSyncServiceToSyncableStore.ts
@@ -150,8 +150,8 @@ export const attachSyncServiceToSyncableStore = makeAsyncResultFunc(
       onFolderRemoved(path);
     });
 
-    DEV: debugTopic('SYNC', (log) => log(`Added needsSync listener for ${store.path.toString()}`));
-    const removeLocalNeedsSyncListener = store.addListener('needsSync', ({ path, hash }) => {
+    DEV: debugTopic('SYNC', (log) => log(`Added itemAdded listener for ${store.path.toString()}`));
+    const removeLocalItemAddedListener = store.addListener('itemAdded', ({ path, hash }) => {
       DEV: debugTopic('SYNC', (log) => log(`Received itemAdded for ${path.toString()}: ${hash}`));
       syncService.pushToRemotes({ path, hash });
     });
@@ -174,7 +174,7 @@ export const attachSyncServiceToSyncableStore = makeAsyncResultFunc(
         removeListenersByFolderPath = {};
         removeLocalFolderAddedListener();
         removeLocalFolderRemovedListener();
-        removeLocalNeedsSyncListener();
+        removeLocalItemAddedListener();
         cancelSchedule();
       }
     });

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/__test_dependency__/makeHotSwappableCryptoServiceForTesting.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/__test_dependency__/makeHotSwappableCryptoServiceForTesting.ts
@@ -9,10 +9,8 @@ export const makeHotSwappableCryptoServiceForTesting = (initialCryptoService: Cr
 
   return {
     getPrivateCryptoKeySetIds: (...args) => activeCryptoService.getPrivateCryptoKeySetIds(...args),
-    getEncryptingKeySetForId: (...args) => activeCryptoService.getEncryptingKeySetForId(...args),
-    getVerifyingKeySetForId: (...args) => activeCryptoService.getVerifyingKeySetForId(...args),
-    getSigningKeySet: (...args) => activeCryptoService.getSigningKeySet(...args),
-    getDecryptingKeySet: (...args) => activeCryptoService.getDecryptingKeySet(...args),
+    getPrivateCryptoKeySet: (...args) => activeCryptoService.getPrivateCryptoKeySet(...args),
+    getPublicCryptoKeySetForId: (...args) => activeCryptoService.getPublicCryptoKeySetForId(...args),
     hotSwap: (newCryptoService) => {
       activeCryptoService = newCryptoService;
     }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
@@ -104,9 +104,9 @@ export class FolderOperationsHandler {
         return makeFailure(new InternalStateError(trace, { message: 'store was released' }));
       }
 
-      const signingKeys = await store.cryptoService.getSigningKeySet(trace);
-      if (!signingKeys.ok) {
-        return generalizeFailureResult(trace, signingKeys, 'not-found');
+      const privateKeys = await store.cryptoService.getPrivateCryptoKeySet(trace);
+      if (!privateKeys.ok) {
+        return generalizeFailureResult(trace, privateKeys, 'not-found');
       }
 
       const signedStoreChange = await generateSignedValue<SyncableStoreChange>(trace, {
@@ -114,7 +114,7 @@ export class FolderOperationsHandler {
         valueSchema: syncableStoreChangeSchema,
         signatureExtras: undefined,
         signatureExtrasSchema: undefined,
-        signingKeys: signingKeys.value
+        signingKeys: privateKeys.value
       });
       if (!signedStoreChange.ok) {
         return signedStoreChange;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/folders.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/folders.test.ts
@@ -5,7 +5,7 @@ import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
-import { defaultSaltId, encName, storageRootIdInfo, syncableItemTypes, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, syncableItemTypes, uuidId } from 'freedom-sync-types';
 import { expectIncludes, expectNotOk, expectOk } from 'freedom-testing-tools';
 
 import type { TestingCryptoService } from '../../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -57,8 +57,8 @@ describe('folders', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));
@@ -74,7 +74,7 @@ describe('folders', () => {
     expectOk(cryptoKeys2);
     primaryUserCryptoService.addPublicKeys({ publicKeys: cryptoKeys2.value.publicOnly() });
 
-    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeyId: cryptoKeys2.value.id, role: 'editor' }));
+    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeys: cryptoKeys2.value, role: 'editor' }));
 
     const secondaryUserCryptoService = makeCryptoServiceForTesting({ privateKeys: cryptoKeys2.value });
     secondaryUserCryptoService.addPublicKeys({ publicKeys: cryptoKeys.publicOnly() });
@@ -102,7 +102,7 @@ describe('folders', () => {
     expectOk(cryptoKeys2);
     primaryUserCryptoService.addPublicKeys({ publicKeys: cryptoKeys2.value.publicOnly() });
 
-    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeyId: cryptoKeys2.value.id, role: 'appender' }));
+    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeys: cryptoKeys2.value, role: 'appender' }));
 
     const secondaryUserCryptoService = makeCryptoServiceForTesting({ privateKeys: cryptoKeys2.value });
     secondaryUserCryptoService.addPublicKeys({ publicKeys: cryptoKeys.publicOnly() });
@@ -137,7 +137,7 @@ describe('folders', () => {
 
     primaryUserCryptoService.addPublicKeys({ publicKeys: cryptoKeys2.value.publicOnly() });
 
-    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeyId: cryptoKeys2.value.id, role: 'editor' }));
+    expectOk(await testingFolder.value.updateAccess(trace, { type: 'add-access', publicKeys: cryptoKeys2.value, role: 'editor' }));
 
     expectOk(
       await testingFolder.value.updateAccess(trace, {

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { defaultSaltId, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -48,8 +48,8 @@ describe('hashes', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncTracker.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncTracker.ts
@@ -5,7 +5,8 @@ import type { SyncableItemType, SyncablePath } from 'freedom-sync-types';
 export type SyncTrackerNotifications = {
   folderAdded: { path: SyncablePath };
   folderRemoved: { path: SyncablePath };
-  needsSync: { type: SyncableItemType; path: SyncablePath; hash: Sha256Hash };
+  /** Called when any item is added, including folders – which also have their own notifications */
+  itemAdded: { type: SyncableItemType; path: SyncablePath; hash: Sha256Hash };
 };
 
 export type SyncTracker = NotificationManager<SyncTrackerNotifications>;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
@@ -1,4 +1,4 @@
-import type { CryptoKeySetId } from 'freedom-crypto-data';
+import type { CombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
 import type { SaltId } from 'freedom-sync-types';
 
@@ -8,9 +8,8 @@ import type { SyncableFolderAccessor } from './SyncableFolderAccessor.ts';
 export interface SyncableStore extends SyncableFolderAccessor {
   readonly localTrustMarks: MutableTrustMarkStore;
 
-  readonly creatorCryptoKeySetId: CryptoKeySetId;
+  readonly creatorPublicKeys: CombinationCryptoKeySet;
   readonly cryptoService: CryptoService;
 
-  readonly defaultSalt: string | undefined;
   readonly saltsById: Partial<Record<SaltId, string>>;
 }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { defaultSaltId, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectErrorCode, expectIncludes, expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -51,8 +51,8 @@ describe('DefaultSyncableStore', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/consts/special-ids.ts
@@ -1,6 +1,5 @@
-import type { Uuid } from 'freedom-basic-data';
-import { Cast } from 'freedom-cast';
+import { ZERO_UUID } from 'freedom-basic-data';
 import { uuidId } from 'freedom-sync-types';
 
 /** This is only used as an internal marker */
-export const ROOT_FOLDER_ID = uuidId('folder', Cast<Uuid>('00000000-0000-0000-0000-000000000000'));
+export const ROOT_FOLDER_ID = uuidId('folder', ZERO_UUID);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/traversePath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/in-memory-backing/internal/utils/traversePath.ts
@@ -2,7 +2,7 @@ import { makeFailure, makeSuccess, makeSyncResultFunc, type Result } from 'freed
 import { NotFoundError } from 'freedom-common-errors';
 import type { Trace } from 'freedom-contexts';
 import type { SyncableId, SyncableItemType } from 'freedom-sync-types';
-import { extractSyncableIdParts, SyncablePath } from 'freedom-sync-types';
+import { extractSyncableItemTypeFromId, SyncablePath } from 'freedom-sync-types';
 import type { SingleOrArray } from 'yaschema';
 
 import { guardIsExpectedType } from '../../../../utils/guards/guardIsExpectedType.ts';
@@ -59,9 +59,8 @@ export const traversePath = makeSyncResultFunc(
       }
     }
 
-    const idParts =
-      path.lastId === undefined ? { encrypted: true, type: 'folder' as const, unmarkedId: '' } : extractSyncableIdParts(path.lastId!);
-    const guards = guardIsExpectedType(trace, path, idParts, expectedType, 'wrong-type');
+    const itemType = path.lastId === undefined ? 'folder' : extractSyncableItemTypeFromId(path.lastId!);
+    const guards = guardIsExpectedType(trace, path, itemType, expectedType, 'wrong-type');
     if (!guards.ok) {
       return guards;
     }

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
@@ -9,7 +9,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { defaultSaltId, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -51,8 +51,8 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { defaultSaltId, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 import { schema } from 'yaschema';
 
@@ -51,8 +51,8 @@ describe('createJsonFileAtPath', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
@@ -6,7 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
-import { defaultSaltId, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
 
 import { makeCryptoServiceForTesting } from '../../__test_dependency__/makeCryptoServiceForTesting.ts';
@@ -48,8 +48,8 @@ describe('createStringFileAtPath', () => {
       storageRootId,
       backing: storeBacking,
       cryptoService,
-      provenance: provenance.value,
-      saltsById: { [defaultSaltId]: makeUuid() }
+      creatorPublicKeys: cryptoKeys.publicOnly(),
+      saltsById: { [DEFAULT_SALT_ID]: makeUuid() }
     });
 
     expectOk(await initializeRoot(trace, store));

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/create/createConflictFreeDocumentBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/create/createConflictFreeDocumentBundleAtPath.ts
@@ -5,7 +5,7 @@ import type { ConflictFreeDocument } from 'freedom-conflict-free-document';
 import type { EncodedConflictFreeDocumentSnapshot } from 'freedom-conflict-free-document-data';
 import { type Trace } from 'freedom-contexts';
 import type { DynamicSyncableItemName, SyncableOriginOptions, SyncablePath } from 'freedom-sync-types';
-import { extractSyncableIdParts, timeId, uuidId } from 'freedom-sync-types';
+import { isSyncableItemEncrypted, timeId, uuidId } from 'freedom-sync-types';
 import type { TrustedTime } from 'freedom-trusted-time-source';
 
 import { makeDeltasBundleId, SNAPSHOTS_BUNDLE_ID } from '../../consts/special-file-ids.ts';
@@ -39,7 +39,7 @@ export const createConflictFreeDocumentBundleAtPath = makeAsyncResultFunc(
     const docPath = docBundle.value.path;
 
     // Snapshots are encrypted if their parent bundle is encrypted
-    const isEncrypted = extractSyncableIdParts(docPath.lastId!).encrypted;
+    const isEncrypted = isSyncableItemEncrypted(docPath.lastId!);
     const snapshots = await createBundleAtPath(trace, store, docPath.append(SNAPSHOTS_BUNDLE_ID({ encrypted: isEncrypted })));
     /* node:coverage disable */
     if (!snapshots.ok) {
@@ -86,7 +86,7 @@ export const createConflictFreeDocumentBundleAtPath = makeAsyncResultFunc(
           }
 
           // Deltas are encrypted if their parent bundle is encrypted
-          const areDeltasEncrypted = extractSyncableIdParts(docPath.lastId!).encrypted;
+          const areDeltasEncrypted = isSyncableItemEncrypted(docPath.lastId!);
           const deltasPath = docPath.append(makeDeltasBundleId({ encrypted: areDeltasEncrypted }, document.snapshotId));
           const deltas = await getBundleAtPath(trace, store, deltasPath);
           if (!deltas.ok) {

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/encryptAndSignBinary.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/encryptAndSignBinary.ts
@@ -15,9 +15,9 @@ export const encryptAndSignBinary = makeAsyncResultFunc(
     value: Uint8Array,
     { accessControlDoc, cryptoService }: { accessControlDoc: SyncableStoreAccessControlDocument; cryptoService: CryptoService }
   ): PR<Uint8Array> => {
-    const signingKeys = await cryptoService.getSigningKeySet(trace);
-    if (!signingKeys.ok) {
-      return generalizeFailureResult(trace, signingKeys, 'not-found');
+    const privateKeys = await cryptoService.getPrivateCryptoKeySet(trace);
+    if (!privateKeys.ok) {
+      return generalizeFailureResult(trace, privateKeys, 'not-found');
     }
 
     const sharedKeys = await accessControlDoc.getSharedKeys(trace);
@@ -48,7 +48,7 @@ export const encryptAndSignBinary = makeAsyncResultFunc(
     }
     /* node:coverage enable */
 
-    const signedEncryptedValue = await generateSignedBuffer(trace, { value: encryptedValue.value, signingKeys: signingKeys.value });
+    const signedEncryptedValue = await generateSignedBuffer(trace, { value: encryptedValue.value, signingKeys: privateKeys.value });
     /* node:coverage disable */
     if (!signedEncryptedValue.ok) {
       return signedEncryptedValue;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/exports.ts
@@ -25,6 +25,8 @@ export * from './guards/exports.ts';
 export * from './initializeRoot.ts';
 export * from './logLs.ts';
 export * from './markSyncableNeedsRecomputeHashAtPath.ts';
+export * from './pull/exports.ts';
+export * from './push/exports.ts';
 export * from './saltedId.ts';
 export * from './shouldUseTrustedTimeIdsInPath.ts';
 export * from './validation/exports.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateAcceptanceForPathIfPossible.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateAcceptanceForPathIfPossible.ts
@@ -66,9 +66,9 @@ const internalGenerateAcceptanceForFileAtPathWithKeySet = makeAsyncResultFunc(
       return trustedTime;
     }
 
-    const signingKeys = await store.cryptoService.getSigningKeySet(trace, cryptoKeySetId);
-    if (!signingKeys.ok) {
-      return generalizeFailureResult(trace, signingKeys, 'not-found');
+    const privateKeys = await store.cryptoService.getPrivateCryptoKeySet(trace, cryptoKeySetId);
+    if (!privateKeys.ok) {
+      return generalizeFailureResult(trace, privateKeys, 'not-found');
     }
 
     return await generateSignedValue(trace, {
@@ -76,7 +76,7 @@ const internalGenerateAcceptanceForFileAtPathWithKeySet = makeAsyncResultFunc(
       valueSchema: syncableAcceptanceSchema,
       signatureExtras: undefined,
       signatureExtrasSchema: undefined,
-      signingKeys: signingKeys.value
+      signingKeys: privateKeys.value
     });
   }
 );

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateOrigin.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateOrigin.ts
@@ -36,9 +36,9 @@ export const generateOrigin = makeAsyncResultFunc(
       contentHash = folderContentHash.value;
     }
 
-    const signingKeys = await cryptoService.getSigningKeySet(trace);
-    if (!signingKeys.ok) {
-      return generalizeFailureResult(trace, signingKeys, 'not-found');
+    const privateKeys = await cryptoService.getPrivateCryptoKeySet(trace);
+    if (!privateKeys.ok) {
+      return generalizeFailureResult(trace, privateKeys, 'not-found');
     }
 
     return await generateSignedValue(trace, {
@@ -46,7 +46,7 @@ export const generateOrigin = makeAsyncResultFunc(
       valueSchema: syncableOriginSchema,
       signatureExtras: { path, type, name },
       signatureExtrasSchema: syncableOriginSignatureExtrasSchema,
-      signingKeys: signingKeys.value
+      signingKeys: privateKeys.value
     });
   }
 );

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateSelfSignedTrustedTime.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/generateSelfSignedTrustedTime.ts
@@ -19,9 +19,9 @@ export const generateSelfSignedTrustedTime = makeAsyncResultFunc(
   ): PR<TrustedTime> => {
     const timeId = timeIdInfo.make(`${makeIsoDateTime()}-${makeUuid()}`);
 
-    const signingKeys = await store.cryptoService.getSigningKeySet(trace);
-    if (!signingKeys.ok) {
-      return generalizeFailureResult(trace, signingKeys, 'not-found');
+    const privateKeys = await store.cryptoService.getPrivateCryptoKeySet(trace);
+    if (!privateKeys.ok) {
+      return generalizeFailureResult(trace, privateKeys, 'not-found');
     }
 
     const trustedTimeSignature = await generateSignatureForValue(trace, {
@@ -29,7 +29,7 @@ export const generateSelfSignedTrustedTime = makeAsyncResultFunc(
       valueSchema: trustedTimeSignatureParamsSchema,
       signatureExtras: undefined,
       signatureExtrasSchema: undefined,
-      signingKeys: signingKeys.value
+      signingKeys: privateKeys.value
     });
     if (!trustedTimeSignature.ok) {
       return trustedTimeSignature;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
@@ -13,7 +13,8 @@ import { ForbiddenError, generalizeFailureResult, NotFoundError } from 'freedom-
 import type { ConflictFreeDocument } from 'freedom-conflict-free-document';
 import type { EncodedConflictFreeDocumentDelta, EncodedConflictFreeDocumentSnapshot } from 'freedom-conflict-free-document-data';
 import type { Trace } from 'freedom-contexts';
-import { extractSyncableIdParts, type SyncablePath, type SyncableProvenance } from 'freedom-sync-types';
+import type { SyncablePath, SyncableProvenance } from 'freedom-sync-types';
+import { isSyncableItemEncrypted } from 'freedom-sync-types';
 import { once } from 'lodash-es';
 
 import { makeDeltasBundleId, SNAPSHOTS_BUNDLE_ID } from '../../consts/special-file-ids.ts';
@@ -72,7 +73,7 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
     /* node:coverage enable */
 
     // Snapshots are encrypted if their parent bundle is encrypted
-    const isSnapshotEncrypted = extractSyncableIdParts(path.lastId!).encrypted;
+    const isSnapshotEncrypted = isSyncableItemEncrypted(path.lastId!);
     const snapshotsPath = path.append(SNAPSHOTS_BUNDLE_ID({ encrypted: isSnapshotEncrypted }));
     const snapshots = await getBundleAtPath(trace, store, snapshotsPath);
     /* node:coverage disable */
@@ -142,7 +143,7 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
       const document = newDocument({ id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<PrefixT> });
 
       // Deltas are encrypted if their parent bundle is encrypted
-      const areDeltaEncrypted = extractSyncableIdParts(path.lastId!).encrypted;
+      const areDeltaEncrypted = isSyncableItemEncrypted(path.lastId!);
       const dynamicDeltasPath = path.append(makeDeltasBundleId({ encrypted: areDeltaEncrypted }, snapshotId));
       const deltas = await getBundleAtPath(trace, store, dynamicDeltasPath);
       /* node:coverage disable */

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/getCryptoKeyIdForHighestCurrentUserRoleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/getCryptoKeyIdForHighestCurrentUserRoleAtPath.ts
@@ -22,9 +22,9 @@ export const getCryptoKeyIdForHighestCurrentUserRoleAtPath = makeAsyncResultFunc
       return privateKeyIds;
     }
 
-    // If the crypto service is the creator, return the creator's key ID
-    if (privateKeyIds.value.includes(store.creatorCryptoKeySetId)) {
-      return makeSuccess({ role: 'creator' as const, cryptoKeySetId: store.creatorCryptoKeySetId });
+    // If the current user is the creator, return the creator's key ID
+    if (privateKeyIds.value.includes(store.creatorPublicKeys.id)) {
+      return makeSuccess({ role: 'creator' as const, cryptoKeySetId: store.creatorPublicKeys.id });
     }
 
     const folderPath = await getFolderPath(trace, store, path);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/guards/guardIsExpectedType.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/guards/guardIsExpectedType.ts
@@ -11,17 +11,19 @@ export const guardIsExpectedType = makeSyncResultFunc(
   <ErrorCodeT extends string>(
     trace: Trace,
     path: SyncablePath,
-    item: { type: SyncableItemType },
+    itemOrType: SyncableItemType | { type: SyncableItemType },
     expectedType: SyncableItemType | Array<SyncableItemType> | undefined,
     errorCode: ErrorCodeT
   ): Result<undefined, ErrorCodeT> => {
-    const isExpected = isExpectedType(trace, item, expectedType);
+    const isExpected = isExpectedType(trace, itemOrType, expectedType);
     if (!isExpected.ok) {
       return isExpected;
     } else if (!isExpected.value) {
+      const type = typeof itemOrType === 'string' ? itemOrType : itemOrType.type;
+
       return makeFailure(
         new NotFoundError(trace, {
-          message: `Expected ${Array.isArray(expectedType) ? expectedType.join(' or ') : expectedType} for ${path.toString()}, found: ${item.type}`,
+          message: `Expected ${Array.isArray(expectedType) ? expectedType.join(' or ') : expectedType} for ${path.toString()}, found: ${type}`,
           errorCode
         })
       );

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/exports.ts
@@ -1,0 +1,4 @@
+export * from './pullBundle.ts';
+export * from './pullFile.ts';
+export * from './pullFolder.ts';
+export * from './pullPath.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullBundle.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullBundle.ts
@@ -1,0 +1,66 @@
+import { excludeFailureResult, makeAsyncResultFunc, makeFailure, makeSuccess, type PR } from 'freedom-async';
+import type { Sha256Hash } from 'freedom-basic-data';
+import { objectEntries } from 'freedom-cast';
+import { generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import type { InSyncBundle, OutOfSyncBundle, SyncableId, SyncablePath } from 'freedom-sync-types';
+
+import type { SyncableStore } from '../../types/SyncableStore.ts';
+import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
+
+export const pullBundle = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace: Trace,
+    store: SyncableStore,
+    { hash: downstreamHash, path }: { path: SyncablePath; hash?: Sha256Hash }
+  ): PR<InSyncBundle | OutOfSyncBundle, 'not-found'> => {
+    const bundle = await getSyncableAtPath(trace, store, path, 'bundle');
+    if (!bundle.ok) {
+      if (bundle.value.errorCode === 'deleted') {
+        // Treating deleted as not found
+        return makeFailure(new NotFoundError(trace, { cause: bundle.value, errorCode: 'not-found' }));
+      }
+      return generalizeFailureResult(trace, excludeFailureResult(bundle, 'deleted'), ['untrusted', 'wrong-type']);
+    }
+
+    const hash = await bundle.value.getHash(trace);
+    if (!hash.ok) {
+      return hash;
+    }
+
+    if (hash.value === downstreamHash) {
+      return makeSuccess({ type: 'bundle', outOfSync: false } satisfies InSyncBundle);
+    }
+
+    const metadata = await bundle.value.getMetadata(trace);
+    if (!metadata.ok) {
+      return metadata;
+    }
+
+    const metadataById = await bundle.value.getMetadataById(trace);
+    if (!metadataById.ok) {
+      return metadataById;
+    }
+
+    const hashesById = objectEntries(metadataById.value).reduce(
+      (out, [id, metadata]) => {
+        if (metadata === undefined) {
+          return out;
+        }
+
+        out[id] = metadata.hash;
+
+        return out;
+      },
+      {} as Partial<Record<SyncableId, Sha256Hash>>
+    );
+
+    return makeSuccess({
+      type: 'bundle',
+      outOfSync: true,
+      hashesById,
+      metadata: metadata.value
+    } satisfies OutOfSyncBundle);
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullFile.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullFile.ts
@@ -1,0 +1,59 @@
+import type { PR } from 'freedom-async';
+import { excludeFailureResult, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import type { Sha256Hash } from 'freedom-basic-data';
+import { generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import type { InSyncFile, OutOfSyncFile, SyncablePath } from 'freedom-sync-types';
+
+import type { SyncableStore } from '../../types/SyncableStore.ts';
+import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
+
+export const pullFile = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace: Trace,
+    store: SyncableStore,
+    { hash: downstreamHash, path, sendData = false }: { path: SyncablePath; hash?: Sha256Hash; sendData?: boolean }
+  ): PR<InSyncFile | OutOfSyncFile, 'not-found'> => {
+    const file = await getSyncableAtPath(trace, store, path, 'file');
+    if (!file.ok) {
+      if (file.value.errorCode === 'deleted') {
+        // Treating deleted as not found
+        return makeFailure(new NotFoundError(trace, { cause: file.value, errorCode: 'not-found' }));
+      }
+      return generalizeFailureResult(trace, excludeFailureResult(file, 'deleted'), ['untrusted', 'wrong-type']);
+    }
+
+    const hash = await file.value.getHash(trace);
+    if (!hash.ok) {
+      return hash;
+    }
+
+    if (hash.value === downstreamHash) {
+      return makeSuccess({ type: 'file', outOfSync: false } satisfies InSyncFile);
+    }
+
+    // TODO: changing provenance (by accepting or rejecting) should probably trigger a hash change or something
+
+    const metadata = await file.value.getMetadata(trace);
+    if (!metadata.ok) {
+      return metadata;
+    }
+
+    if (!sendData) {
+      return makeSuccess({ type: 'file', outOfSync: true, metadata: metadata.value } satisfies OutOfSyncFile);
+    } else {
+      const data = await file.value.getEncodedBinary(trace);
+      if (!data.ok) {
+        return data;
+      }
+
+      return makeSuccess({
+        type: 'file',
+        outOfSync: true,
+        data: data.value,
+        metadata: metadata.value
+      } satisfies OutOfSyncFile);
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullFolder.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullFolder.ts
@@ -1,0 +1,66 @@
+import { excludeFailureResult, makeAsyncResultFunc, makeFailure, makeSuccess, type PR } from 'freedom-async';
+import type { Sha256Hash } from 'freedom-basic-data';
+import { objectEntries } from 'freedom-cast';
+import { generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import type { InSyncFolder, OutOfSyncFolder, SyncableId, SyncablePath } from 'freedom-sync-types';
+
+import type { SyncableStore } from '../../types/SyncableStore.ts';
+import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
+
+export const pullFolder = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace: Trace,
+    store: SyncableStore,
+    { hash: downstreamHash, path }: { path: SyncablePath; hash?: Sha256Hash }
+  ): PR<InSyncFolder | OutOfSyncFolder, 'not-found'> => {
+    const folder = await getSyncableAtPath(trace, store, path, 'folder');
+    if (!folder.ok) {
+      if (folder.value.errorCode === 'deleted') {
+        // Treating deleted as not found
+        return makeFailure(new NotFoundError(trace, { cause: folder.value, errorCode: 'not-found' }));
+      }
+      return generalizeFailureResult(trace, excludeFailureResult(folder, 'deleted'), ['untrusted', 'wrong-type']);
+    }
+
+    const hash = await folder.value.getHash(trace);
+    if (!hash.ok) {
+      return hash;
+    }
+
+    if (hash.value === downstreamHash) {
+      return makeSuccess({ type: 'folder', outOfSync: false } satisfies InSyncFolder);
+    }
+
+    const metadata = await folder.value.getMetadata(trace);
+    if (!metadata.ok) {
+      return metadata;
+    }
+
+    const metadataById = await folder.value.getMetadataById(trace);
+    if (!metadataById.ok) {
+      return metadataById;
+    }
+
+    const hashesById = objectEntries(metadataById.value).reduce(
+      (out, [id, metadata]) => {
+        if (metadata === undefined) {
+          return out;
+        }
+
+        out[id] = metadata.hash;
+
+        return out;
+      },
+      {} as Partial<Record<SyncableId, Sha256Hash>>
+    );
+
+    return makeSuccess({
+      type: 'folder',
+      outOfSync: true,
+      hashesById,
+      metadata: metadata.value
+    } satisfies OutOfSyncFolder);
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/pull/pullPath.ts
@@ -1,0 +1,31 @@
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { SyncPullArgs, SyncPullResponse } from 'freedom-sync-types';
+
+import type { SyncableStore } from '../../types/SyncableStore.ts';
+import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
+import { pullBundle } from './pullBundle.ts';
+import { pullFile } from './pullFile.ts';
+import { pullFolder } from './pullFolder.ts';
+
+export const pullPath = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, store: SyncableStore, args: SyncPullArgs): PR<SyncPullResponse, 'not-found'> => {
+    const syncableItem = await getSyncableAtPath(trace, store, args.path);
+    if (!syncableItem.ok) {
+      return generalizeFailureResult(trace, syncableItem, ['deleted', 'untrusted', 'wrong-type']);
+    }
+
+    switch (syncableItem.value.type) {
+      case 'folder':
+        return await pullFolder(trace, store, args);
+
+      case 'file':
+        return await pullFile(trace, store, args);
+
+      case 'bundle':
+        return await pullBundle(trace, store, args);
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/exports.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/exports.ts
@@ -1,0 +1,4 @@
+export * from './pushBundle.ts';
+export * from './pushFile.ts';
+export * from './pushFolder.ts';
+export * from './pushPath.ts';

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushBundle.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushBundle.ts
@@ -1,0 +1,38 @@
+import type { PR } from 'freedom-async';
+import { excludeFailureResult, makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { SyncableItemMetadata, SyncablePath } from 'freedom-sync-types';
+
+import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
+import { createViaSyncBundleAtPath } from '../via-sync/createViaSyncBundleAtPath.ts';
+
+export const pushBundle = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    store: MutableSyncableStore,
+    {
+      path,
+      metadata
+    }: {
+      path: SyncablePath;
+      metadata: SyncableItemMetadata;
+    }
+  ): PR<undefined> => {
+    const bundle = await createViaSyncBundleAtPath(trace, store, path, metadata);
+    if (!bundle.ok) {
+      if (bundle.value.errorCode === 'deleted') {
+        // Was locally (with respect to the mock remote) deleted, so not interested in this content
+        return makeSuccess(undefined);
+      }
+      return generalizeFailureResult(
+        trace,
+        excludeFailureResult(bundle, 'deleted'),
+        ['conflict', 'not-found', 'untrusted', 'wrong-type'],
+        `Failed to push bundle file: ${path.toString()}`
+      );
+    }
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushFile.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushFile.ts
@@ -1,0 +1,40 @@
+import type { PR } from 'freedom-async';
+import { excludeFailureResult, makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { SyncableItemMetadata, SyncablePath } from 'freedom-sync-types';
+
+import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
+import { createViaSyncPreEncodedBinaryFileAtPath } from '../via-sync/createViaSyncPreEncodedBinaryFileAtPath.ts';
+
+export const pushFile = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    store: MutableSyncableStore,
+    {
+      path,
+      data,
+      metadata
+    }: {
+      path: SyncablePath;
+      data: Uint8Array;
+      metadata: SyncableItemMetadata;
+    }
+  ): PR<undefined> => {
+    const file = await createViaSyncPreEncodedBinaryFileAtPath(trace, store, path, data, metadata);
+    if (!file.ok) {
+      if (file.value.errorCode === 'deleted') {
+        // Was locally (with respect to the mock remote) deleted, so not interested in this content
+        return makeSuccess(undefined);
+      }
+      return generalizeFailureResult(
+        trace,
+        excludeFailureResult(file, 'deleted'),
+        ['conflict', 'not-found', 'untrusted', 'wrong-type'],
+        `Failed to push flat file: ${path.toString()}`
+      );
+    }
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushFolder.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushFolder.ts
@@ -1,0 +1,43 @@
+import type { PR } from 'freedom-async';
+import { excludeFailureResult, makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { SyncableItemMetadata, SyncablePath } from 'freedom-sync-types';
+
+import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
+import { createViaSyncFolderAtPath } from '../via-sync/createViaSyncFolderAtPath.ts';
+
+export const pushFolder = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    store: MutableSyncableStore,
+    {
+      path,
+      metadata
+    }: {
+      path: SyncablePath;
+      metadata: SyncableItemMetadata;
+    }
+  ): PR<undefined> => {
+    if (path.ids.length === 0) {
+      // Nothing to do for root
+      return makeSuccess(undefined);
+    }
+
+    const folder = await createViaSyncFolderAtPath(trace, store, path, metadata);
+    if (!folder.ok) {
+      if (folder.value.errorCode === 'deleted') {
+        // Was locally (with respect to the mock remote) deleted, so not interested in this content
+        return makeSuccess(undefined);
+      }
+      return generalizeFailureResult(
+        trace,
+        excludeFailureResult(folder, 'deleted'),
+        ['conflict', 'not-found', 'untrusted', 'wrong-type'],
+        `Failed to push folder: ${path.toString()}`
+      );
+    }
+
+    return makeSuccess(undefined);
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/push/pushPath.ts
@@ -1,0 +1,24 @@
+import type { PR } from 'freedom-async';
+import { makeAsyncResultFunc } from 'freedom-async';
+import type { SyncPushArgs } from 'freedom-sync-types';
+
+import type { MutableSyncableStore } from '../../types/MutableSyncableStore.ts';
+import { pushBundle } from './pushBundle.ts';
+import { pushFile } from './pushFile.ts';
+import { pushFolder } from './pushFolder.ts';
+
+export const pushPath = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (trace, store: MutableSyncableStore, args: SyncPushArgs): PR<undefined> => {
+    switch (args.type) {
+      case 'folder':
+        return await pushFolder(trace, store, args);
+
+      case 'bundle':
+        return await pushBundle(trace, store, args);
+
+      case 'file':
+        return await pushFile(trace, store, args);
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/saltedId.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/saltedId.ts
@@ -1,32 +1,42 @@
 import { GeneralError } from 'freedom-async';
 import { makeTrace } from 'freedom-contexts';
-import { generateHashFromString } from 'freedom-crypto';
-import type { SyncableId, SyncableIdSettings } from 'freedom-sync-types';
-import { makeSyncableId, unmarkedSyncableSaltedIdInfo } from 'freedom-sync-types';
+import type { SaltId, SyncableId, SyncableIdConfig, SyncableItemType } from 'freedom-sync-types';
+import { DEFAULT_SALT_ID, makeSyncableId, unmarkedSyncableSaltedIdInfo } from 'freedom-sync-types';
 
 import type { SyncableStore } from '../types/SyncableStore.ts';
 
 const trace = makeTrace(import.meta.filename);
 
+export interface SyncableSaltedIdConfig extends SyncableIdConfig {
+  defaultSaltId?: SaltId;
+}
+
+export type SyncableSaltedIdSettings = SyncableItemType | SyncableSaltedIdConfig;
+
 // Not using makeAsyncResultFunc here because we want this to be easily inlined for readability
 export const saltedId =
-  (settings: SyncableIdSettings, plainId: string) =>
+  (settings: SyncableSaltedIdSettings, plainId: string) =>
   async (salt: SyncableStore | string | undefined): Promise<SyncableId> => {
     if (salt === undefined) {
       throw new GeneralError(trace, 'Salt is required');
     }
 
-    const saltString = typeof salt === 'string' ? salt : salt.defaultSalt;
+    const defaultSaltId = (typeof settings === 'string' ? undefined : settings.defaultSaltId) ?? DEFAULT_SALT_ID;
+
+    const saltString = typeof salt === 'string' ? salt : salt.saltsById[defaultSaltId];
     if (saltString === undefined) {
       throw new GeneralError(trace, 'Salt is required');
     }
 
-    // TODO: could probably cache these
-    const hash = await generateHashFromString(trace, { value: `${saltString}:${plainId}` });
-    if (!hash.ok) {
-      // This shouldn't really ever happen
-      throw new GeneralError(trace, hash.value);
-    }
+    // TODO: TEMP
+    return makeSyncableId(settings, unmarkedSyncableSaltedIdInfo.make(plainId));
 
-    return makeSyncableId(settings, unmarkedSyncableSaltedIdInfo.make(Buffer.from(hash.value).toString('base64')));
+    // TODO: could probably cache these
+    // const hash = await generateHashFromString(trace, { value: `${saltString}:${plainId}` });
+    // if (!hash.ok) {
+    //   // This shouldn't really ever happen
+    //   throw new GeneralError(trace, hash.value);
+    // }
+
+    // return makeSyncableId(settings, unmarkedSyncableSaltedIdInfo.make(Buffer.from(hash.value).toString('base64')));
   };

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/getRoleForOriginWithPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/getRoleForOriginWithPath.ts
@@ -15,12 +15,12 @@ export const getRoleForOriginWithPath = makeAsyncResultFunc(
     store: SyncableStore,
     { path, origin }: { path: SyncablePath; origin: SignedSyncableOrigin }
   ): PR<SyncableStoreRole | undefined, 'deleted' | 'not-found' | 'untrusted' | 'wrong-type'> => {
-    const signingCryptoKeySetId = extractKeyIdFromSignedValue(trace, { signedValue: origin });
-    if (!signingCryptoKeySetId.ok) {
-      return signingCryptoKeySetId;
+    const signedByKeyId = extractKeyIdFromSignedValue(trace, { signedValue: origin });
+    if (!signedByKeyId.ok) {
+      return signedByKeyId;
     }
 
-    if (signingCryptoKeySetId.value === store.creatorCryptoKeySetId) {
+    if (signedByKeyId.value === store.creatorPublicKeys.id) {
       return makeSuccess('creator' as const);
     }
 
@@ -34,11 +34,11 @@ export const getRoleForOriginWithPath = makeAsyncResultFunc(
       return folder;
     }
 
-    const rolesByCryptoKeySetId = await folder.value.getRolesByCryptoKeySetId(trace, { cryptoKeySetIds: [signingCryptoKeySetId.value] });
+    const rolesByCryptoKeySetId = await folder.value.getRolesByCryptoKeySetId(trace, { cryptoKeySetIds: [signedByKeyId.value] });
     if (!rolesByCryptoKeySetId.ok) {
       return rolesByCryptoKeySetId;
     }
 
-    return makeSuccess(rolesByCryptoKeySetId.value[signingCryptoKeySetId.value]);
+    return makeSuccess(rolesByCryptoKeySetId.value[signedByKeyId.value]);
   }
 );

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/internal/isAcceptanceValid.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/internal/isAcceptanceValid.ts
@@ -31,12 +31,18 @@ export const isAcceptanceValid = makeAsyncResultFunc(
       return generalizeFailureResult(trace, signedByKeyId, 'not-found');
     }
 
-    const verifyingKeys = await store.cryptoService.getVerifyingKeySetForId(trace, signedByKeyId.value);
-    if (!verifyingKeys.ok) {
-      return generalizeFailureResult(trace, verifyingKeys, 'not-found');
+    // TODO: TEMP
+    if (Math.random() < 1) {
+      return makeSuccess(true);
     }
 
-    const signedValueValid = await isSignedValueValid(trace, acceptance, undefined, { verifyingKeys: verifyingKeys.value });
+    // TODO: this should look up from document
+    const signedByPublicKeys = await store.cryptoService.getPublicCryptoKeySetForId(trace, signedByKeyId.value);
+    if (!signedByPublicKeys.ok) {
+      return generalizeFailureResult(trace, signedByPublicKeys, 'not-found');
+    }
+
+    const signedValueValid = await isSignedValueValid(trace, acceptance, undefined, { verifyingKeys: signedByPublicKeys.value });
     if (!signedValueValid.ok) {
       return signedValueValid;
     } else if (!signedValueValid.value) {
@@ -45,7 +51,7 @@ export const isAcceptanceValid = makeAsyncResultFunc(
     }
 
     // If the acceptance was signed by the creator, then it's always valid.  Otherwise, we'll do additional checks
-    if (signedByKeyId.value === store.creatorCryptoKeySetId) {
+    if (signedByKeyId.value === store.creatorPublicKeys.id) {
       return makeSuccess(true);
     }
 

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/isExpectedType.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/validation/isExpectedType.ts
@@ -7,15 +7,17 @@ export const isExpectedType = makeSyncResultFunc(
   [import.meta.filename],
   (
     _trace: Trace,
-    item: { type: SyncableItemType },
+    itemOrType: SyncableItemType | { type: SyncableItemType },
     expectedType: SyncableItemType | Array<SyncableItemType> | undefined
   ): Result<boolean> => {
+    const type = typeof itemOrType === 'string' ? itemOrType : itemOrType.type;
+
     if (expectedType === undefined) {
       return makeSuccess(true);
     } else if (Array.isArray(expectedType)) {
-      return makeSuccess((expectedType as string[]).includes(item.type));
+      return makeSuccess((expectedType as string[]).includes(type));
     } else {
-      return makeSuccess(expectedType === item.type);
+      return makeSuccess(expectedType === type);
     }
   }
 );

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/verifyAndDecryptBinary.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/verifyAndDecryptBinary.ts
@@ -33,14 +33,14 @@ export const verifyAndDecryptBinary = makeAsyncResultFunc(
       return generalizeFailureResult(trace, signedByKeyId, 'not-found');
     }
 
-    const verifyingKeys = await cryptoService.getVerifyingKeySetForId(trace, signedByKeyId.value);
-    if (!verifyingKeys.ok) {
-      return generalizeFailureResult(trace, verifyingKeys, 'not-found');
+    const signedByPublicKeys = await accessControlDoc.getPublicKeysById(trace, signedByKeyId.value);
+    if (!signedByPublicKeys.ok) {
+      return generalizeFailureResult(trace, signedByPublicKeys, 'not-found');
     }
 
     const isSignatureValid = await isSignatureValidForSignedBuffer(trace, {
       signedBuffer: signedEncryptedValue,
-      verifyingKeys: verifyingKeys.value
+      verifyingKeys: signedByPublicKeys.value
     });
     /* node:coverage disable */
     if (!isSignatureValid.ok) {


### PR DESCRIPTION
- AccessControlDocuments now directly include the public keys of folder members, so they don't need to / shouldn't be looked up from any external sources
- A few schema types are now wrapped with SerializedValue, since they require async serialization / deserialization but need to be used in CRDTs which only support sync serialization
- Simplified CryptoService
- Much better internal routing in DefaultMutableSyncableFolderAccessorBase
- Centralized push and pull handler logic (hooked up in commit to follow

_Note that isAcceptanceValid and isOriginValid are temporarily effectively disabled such that they always return true, this will be resolved shortly_