### PR TITLE
Trace Probe

### DIFF
--- a/code/cross-platform-packages/freedom-async/src/context/exports.ts
+++ b/code/cross-platform-packages/freedom-async/src/context/exports.ts
@@ -1,0 +1,1 @@
+export * from './probe.ts';

--- a/code/cross-platform-packages/freedom-async/src/context/probe.ts
+++ b/code/cross-platform-packages/freedom-async/src/context/probe.ts
@@ -1,0 +1,16 @@
+import type { Trace } from 'freedom-contexts';
+import { createTraceContext, useTraceContext } from 'freedom-contexts';
+
+const ProbeSettingsContext = createTraceContext<{ enabled: boolean; args: boolean; results: boolean }>(() => ({
+  enabled: false,
+  args: false,
+  results: false
+}));
+
+export const useProbeSettings = (trace: Trace) => useTraceContext(trace, ProbeSettingsContext);
+
+export const probeSettingsProvider = <ReturnT>(
+  trace: Trace,
+  { enabled, args = false, results = false }: { enabled: boolean; args?: boolean; results?: boolean },
+  callback: (trace: Trace) => ReturnT
+) => ProbeSettingsContext.provider(trace, { enabled, args, results }, callback);

--- a/code/cross-platform-packages/freedom-async/src/exports.ts
+++ b/code/cross-platform-packages/freedom-async/src/exports.ts
@@ -1,4 +1,5 @@
 export * from './config/exports.ts';
 export * from './consts/exports.ts';
+export * from './context/exports.ts';
 export * from './types/exports.ts';
 export * from './utils/exports.ts';

--- a/code/cross-platform-packages/freedom-async/src/internal/debugging/args.ts
+++ b/code/cross-platform-packages/freedom-async/src/internal/debugging/args.ts
@@ -2,6 +2,7 @@
 
 import { devMakeEnvDerivative, type Trace } from 'freedom-contexts';
 
+import { useProbeSettings } from '../../context/probe.ts';
 import { genericValueToString } from '../utils/genericValueToString.ts';
 import { makeShouldIncludeTraceForDebuggingFunc } from './makeShouldIncludeTraceForDebuggingFunc.ts';
 
@@ -9,9 +10,10 @@ export let shouldLogFuncArgs: (trace: Trace) => boolean = () => false;
 export let argsToStrings: (args: any[]) => string[];
 
 DEV: {
-  shouldLogFuncArgs = devMakeEnvDerivative('FREEDOM_LOG_ARGS', process.env.FREEDOM_LOG_ARGS, (envValue) =>
-    makeShouldIncludeTraceForDebuggingFunc(envValue)
-  );
+  shouldLogFuncArgs = devMakeEnvDerivative('FREEDOM_LOG_ARGS', process.env.FREEDOM_LOG_ARGS, (envValue) => (trace) => {
+    const probeSettings = useProbeSettings(trace);
+    return (probeSettings.enabled && probeSettings.args) || makeShouldIncludeTraceForDebuggingFunc(envValue)(trace);
+  });
 
   argsToStrings = (args) => {
     const out: string[] = ['ARGS:'];

--- a/code/cross-platform-packages/freedom-async/src/internal/debugging/funcs.ts
+++ b/code/cross-platform-packages/freedom-async/src/internal/debugging/funcs.ts
@@ -2,14 +2,17 @@
 
 import { devMakeEnvDerivative, type Trace } from 'freedom-contexts';
 
+import { useProbeSettings } from '../../context/probe.ts';
 import { makeShouldIncludeTraceForDebuggingFunc } from './makeShouldIncludeTraceForDebuggingFunc.ts';
 
 export let shouldLogFunc: (trace: Trace) => boolean = () => false;
 export let shouldLogFailures: (trace: Trace) => boolean = () => false;
 
 DEV: {
-  shouldLogFunc = devMakeEnvDerivative('FREEDOM_LOG_FUNCS', process.env.FREEDOM_LOG_FUNCS, (envValue) =>
-    makeShouldIncludeTraceForDebuggingFunc(envValue ?? 'all')
+  shouldLogFunc = devMakeEnvDerivative(
+    'FREEDOM_LOG_FUNCS',
+    process.env.FREEDOM_LOG_FUNCS,
+    (envValue) => (trace) => useProbeSettings(trace).enabled || makeShouldIncludeTraceForDebuggingFunc(envValue ?? 'all')(trace)
   );
   shouldLogFailures = devMakeEnvDerivative('FREEDOM_LOG_FAILURES', process.env.FREEDOM_LOG_FAILURES, (envValue) =>
     makeShouldIncludeTraceForDebuggingFunc(envValue ?? 'all')

--- a/code/cross-platform-packages/freedom-async/src/internal/debugging/results.ts
+++ b/code/cross-platform-packages/freedom-async/src/internal/debugging/results.ts
@@ -2,6 +2,7 @@
 
 import { devMakeEnvDerivative, type Trace } from 'freedom-contexts';
 
+import { useProbeSettings } from '../../context/probe.ts';
 import { genericValueToString } from '../utils/genericValueToString.ts';
 import { makeShouldIncludeTraceForDebuggingFunc } from './makeShouldIncludeTraceForDebuggingFunc.ts';
 
@@ -9,7 +10,8 @@ export let shouldLogFuncResult: (trace: Trace) => boolean = () => false;
 export const resultToString = genericValueToString;
 
 DEV: {
-  shouldLogFuncResult = devMakeEnvDerivative('FREEDOM_LOG_RESULTS', process.env.FREEDOM_LOG_RESULTS, (envValue) =>
-    makeShouldIncludeTraceForDebuggingFunc(envValue)
-  );
+  shouldLogFuncResult = devMakeEnvDerivative('FREEDOM_LOG_RESULTS', process.env.FREEDOM_LOG_RESULTS, (envValue) => (trace) => {
+    const probeSettings = useProbeSettings(trace);
+    return (probeSettings.enabled && probeSettings.results) || makeShouldIncludeTraceForDebuggingFunc(envValue)(trace);
+  });
 }


### PR DESCRIPTION
- Use problemSettingsProvider (DEV build mode only) to enable logging, optionally including args and results, for everything inside a specified trace