### PR TITLE
add .obsidian folder to root

### DIFF
--- a/.obsidian/.gitignore
+++ b/.obsidian/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitignore
+
+# These settings are important for consistency and to follow our standards
+!app.json
+
+# Not adding other config files to git
+# Recommended plugins:
+#   Obsidian Smart Typography - https://github.com/mgmeyers/obsidian-smart-typography

--- a/.obsidian/app.json
+++ b/.obsidian/app.json
@@ -1,0 +1,10 @@
+{
+  "alwaysUpdateLinks": true,
+  "newFileLocation": "current",
+  "useMarkdownLinks": true,
+  "showUnsupportedFiles": true,
+  "attachmentFolderPath": "./assets",
+  "newLinkFormat": "relative",
+  "useTab": false,
+  "showInlineTitle": false
+}


### PR DESCRIPTION
I opened Obsidian on the root instead of docs which I think might be common? If so, I'm thinking we should copy the .obsidian config folder also into the root.