### PR TITLE
Live Documents

### DIFF
--- a/code/cross-platform-packages/freedom-syncable-store-types/package.json
+++ b/code/cross-platform-packages/freedom-syncable-store-types/package.json
@@ -13,6 +13,7 @@
     "freedom-crypto-data": "0.0.0",
     "freedom-crypto-service": "0.0.0",
     "freedom-dev-logging-support": "0.0.0",
+    "freedom-locking-types": "0.0.0",
     "freedom-logging-types": "0.0.0",
     "freedom-notification-types": "0.0.0",
     "freedom-serialization": "0.0.0",

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/consts/timing.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/consts/timing.ts
@@ -1,1 +1,4 @@
-export const APPLY_DELTAS_LIMIT_TIME_MSEC = 1000 / 60;
+import { ONE_SEC_MSEC } from 'freedom-basic-data';
+
+export const APPLY_DELTAS_LIMIT_TIME_MSEC = ONE_SEC_MSEC / 60;
+export const DOCUMENT_CACHE_DURATION_MSEC = 30 * ONE_SEC_MSEC;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/FolderOperationsHandler.ts
@@ -22,9 +22,6 @@ export class FolderOperationsHandler {
   private getMutableSyncableStoreChangesDocument_: PRFunc<SaveableDocument<SyncableStoreChangesDocument>>;
   private readonly weakStore_: WeakRef<MutableSyncableStore>;
 
-  // TODO: TEMP - this should work as a live document
-  // private storeChangesDoc_: SaveableDocument<SyncableStoreChangesDocument> | undefined;
-
   constructor({
     store,
     getAccessControlDocument,
@@ -82,16 +79,11 @@ export class FolderOperationsHandler {
   public readonly isPathMarkedAsDeleted = makeAsyncResultFunc(
     [import.meta.filename, 'isPathMarkedAsDeleted'],
     async (trace, path: SyncablePath): PR<boolean> => {
-      // TODO: TEMP - this should work as a live document
-      // if (this.storeChangesDoc_ === undefined) {
       const storeChangesDoc = await this.getMutableSyncableStoreChangesDocument_(trace);
       if (!storeChangesDoc.ok) {
         return storeChangesDoc;
       }
-      //   this.storeChangesDoc_ = storeChangesDoc.value;
-      // }
 
-      // return makeSuccess(this.storeChangesDoc_.document.isDeletedPath(path));
       return makeSuccess(storeChangesDoc.value.document.isDeletedPath(path));
     }
   );
@@ -120,22 +112,16 @@ export class FolderOperationsHandler {
         return signedStoreChange;
       }
 
-      // TODO: TEMP - this should work as a live document
-      // if (this.storeChangesDoc_ === undefined) {
       const storeChangesDoc = await this.getMutableSyncableStoreChangesDocument_(trace);
       if (!storeChangesDoc.ok) {
         return storeChangesDoc;
       }
-      //   this.storeChangesDoc_ = storeChangesDoc.value;
-      // }
 
-      // const storeChangeAdded = await this.storeChangesDoc_.document.addChange(trace, signedStoreChange.value);
       const storeChangeAdded = await storeChangesDoc.value.document.addChange(trace, signedStoreChange.value);
       if (!storeChangeAdded.ok) {
         return storeChangeAdded;
       }
 
-      // const savedStoreChangesDoc = await this.storeChangesDoc_.save(trace);
       const savedStoreChangesDoc = await storeChangesDoc.value.save(trace);
       if (!savedStoreChangesDoc.ok) {
         return generalizeFailureResult(trace, savedStoreChangesDoc, 'conflict');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/folders.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/folders.test.ts
@@ -1,5 +1,5 @@
 import type { TestContext } from 'node:test';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
@@ -20,6 +20,7 @@ import { createBundleAtPath } from '../../../utils/create/createBundleAtPath.ts'
 import { createFolderAtPath } from '../../../utils/create/createFolderAtPath.ts';
 import { createStringFileAtPath } from '../../../utils/create/createStringFileAtPath.ts';
 import { generateProvenanceForNewSyncableStore } from '../../../utils/generateProvenanceForNewSyncableStore.ts';
+import { clearDocumentCache } from '../../../utils/get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { getFolderAtPath } from '../../../utils/get/getFolderAtPath.ts';
 import { getStringFromFile } from '../../../utils/get/getStringFromFile.ts';
 import { initializeRoot } from '../../../utils/initializeRoot.ts';
@@ -34,6 +35,8 @@ describe('folders', () => {
   let store!: DefaultSyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
+
+  afterEach(clearDocumentCache);
 
   beforeEach(async () => {
     trace = makeTrace('test');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/internal/types/__tests__/hashes.test.ts
@@ -1,5 +1,5 @@
 import type { SuiteContext, TestContext } from 'node:test';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
@@ -16,6 +16,7 @@ import { createBinaryFileAtPath } from '../../../utils/create/createBinaryFileAt
 import { createBundleAtPath } from '../../../utils/create/createBundleAtPath.ts';
 import { createFolderAtPath } from '../../../utils/create/createFolderAtPath.ts';
 import { generateProvenanceForNewSyncableStore } from '../../../utils/generateProvenanceForNewSyncableStore.ts';
+import { clearDocumentCache } from '../../../utils/get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { initializeRoot } from '../../../utils/initializeRoot.ts';
 
 describe('hashes', () => {
@@ -26,6 +27,8 @@ describe('hashes', () => {
   let store!: DefaultSyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
+
+  afterEach(clearDocumentCache);
 
   beforeEach(async (_t: TestContext | SuiteContext) => {
     trace = makeTrace('test');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/DefaultSyncableStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/DefaultSyncableStore.ts
@@ -1,3 +1,4 @@
+import { makeUuid } from 'freedom-contexts';
 import type { CombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
 import { makeDevLoggingSupport } from 'freedom-dev-logging-support';
@@ -22,6 +23,7 @@ export interface DefaultSyncableStoreConstructorArgs {
 }
 
 export class DefaultSyncableStore extends DefaultMutableSyncableFolderAccessorBase implements MutableSyncableStore {
+  public readonly uid = makeUuid();
   public readonly creatorPublicKeys: CombinationCryptoKeySet;
   public readonly cryptoService: CryptoService;
   public readonly saltsById: Partial<Record<SaltId, string>>;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/SyncableStore.ts
@@ -10,6 +10,8 @@ import type { SyncableStoreLogEntry } from './SyncableStoreLogEntry.ts';
 import type { SyncTrackerNotifications } from './SyncTracker.ts';
 
 export interface SyncableStore extends SyncableFolderAccessor, Notifiable<SyncTrackerNotifications> {
+  readonly uid: string;
+
   readonly localTrustMarks: MutableTrustMarkStore;
 
   readonly creatorPublicKeys: CombinationCryptoKeySet;

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/__tests__/DefaultSyncableStore.test.ts
@@ -1,5 +1,5 @@
 import type { TestContext } from 'node:test';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 
 import { encName, uuidId } from 'freedom-sync-types';
 import { expectErrorCode, expectIncludes, expectOk } from 'freedom-testing-tools';
@@ -8,11 +8,14 @@ import { createStoreTestStack } from '../../tests/createStoreTestStack.ts';
 import { createFolderAtPath } from '../../utils/create/createFolderAtPath.ts';
 import { createStringFileAtPath } from '../../utils/create/createStringFileAtPath.ts';
 import { deleteSyncableItemAtPath } from '../../utils/deleteSyncableItemAtPath.ts';
+import { clearDocumentCache } from '../../utils/get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { getFolderAtPath } from '../../utils/get/getFolderAtPath.ts';
 import { getMutableFolderAtPath } from '../../utils/get/getMutableFolderAtPath.ts';
 import { getStringFromFile } from '../../utils/get/getStringFromFile.ts';
 
 describe('DefaultSyncableStore', () => {
+  afterEach(clearDocumentCache);
+
   it('deleting files and folders should work', async (t: TestContext) => {
     const { trace, store } = await createStoreTestStack();
 

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
@@ -1,5 +1,5 @@
 import type { TestContext } from 'node:test';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { makeSuccess } from 'freedom-async';
 import { ConflictFreeDocument } from 'freedom-conflict-free-document';
@@ -18,7 +18,7 @@ import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMe
 import { createConflictFreeDocumentBundleAtPath } from '../create/createConflictFreeDocumentBundleAtPath.ts';
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
 import { generateProvenanceForNewSyncableStore } from '../generateProvenanceForNewSyncableStore.ts';
-import { getConflictFreeDocumentFromBundleAtPath } from '../get/getConflictFreeDocumentFromBundleAtPath.ts';
+import { clearDocumentCache, getConflictFreeDocumentFromBundleAtPath } from '../get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { getMutableConflictFreeDocumentFromBundleAtPath } from '../get/getMutableConflictFreeDocumentFromBundleAtPath.ts';
 import { initializeRoot } from '../initializeRoot.ts';
 
@@ -30,6 +30,8 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
   let store!: DefaultSyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
+
+  afterEach(clearDocumentCache);
 
   beforeEach(async () => {
     trace = makeTrace('test');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createJsonFileAtPath.test.ts
@@ -1,5 +1,5 @@
 import type { TestContext } from 'node:test';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
@@ -16,6 +16,7 @@ import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMe
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
 import { createJsonFileAtPath } from '../create/createJsonFileAtPath.ts';
 import { generateProvenanceForNewSyncableStore } from '../generateProvenanceForNewSyncableStore.ts';
+import { clearDocumentCache } from '../get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { getJsonFromFile } from '../get/getJsonFromFile.ts';
 import { initializeRoot } from '../initializeRoot.ts';
 
@@ -29,6 +30,8 @@ describe('createJsonFileAtPath', () => {
   let store!: DefaultSyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
+
+  afterEach(clearDocumentCache);
 
   beforeEach(async () => {
     trace = makeTrace('test');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/__tests__/createStringFileAtPath.test.ts
@@ -1,5 +1,5 @@
 import type { TestContext } from 'node:test';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
@@ -15,6 +15,7 @@ import { InMemorySyncableStoreBacking } from '../../types/in-memory-backing/InMe
 import { createFolderAtPath } from '../create/createFolderAtPath.ts';
 import { createStringFileAtPath } from '../create/createStringFileAtPath.ts';
 import { generateProvenanceForNewSyncableStore } from '../generateProvenanceForNewSyncableStore.ts';
+import { clearDocumentCache } from '../get/getConflictFreeDocumentFromBundleAtPath.ts';
 import { getStringFromFile } from '../get/getStringFromFile.ts';
 import { initializeRoot } from '../initializeRoot.ts';
 
@@ -26,6 +27,8 @@ describe('createStringFileAtPath', () => {
   let store!: DefaultSyncableStore;
 
   const storageRootId = storageRootIdInfo.make('test');
+
+  afterEach(clearDocumentCache);
 
   beforeEach(async () => {
     trace = makeTrace('test');

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
@@ -1,17 +1,19 @@
 import type { AccessControlDocumentPrefix } from 'freedom-access-control-types';
 import type { PR, PRFunc } from 'freedom-async';
 import { debugTopic, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { objectValues } from 'freedom-cast';
 import { ForbiddenError, generalizeFailureResult, NotFoundError } from 'freedom-common-errors';
 import type { ConflictFreeDocument } from 'freedom-conflict-free-document';
 import type { EncodedConflictFreeDocumentDelta, EncodedConflictFreeDocumentSnapshot } from 'freedom-conflict-free-document-data';
-import type { Trace } from 'freedom-contexts';
+import { makeUuid, type Trace } from 'freedom-contexts';
+import { InMemoryLockStore, withAcquiredLock } from 'freedom-locking-types';
 import { NotificationManager } from 'freedom-notification-types';
 import type { SyncablePath } from 'freedom-sync-types';
 import { isSyncableItemEncrypted } from 'freedom-sync-types';
 import { TaskQueue } from 'freedom-task-queue';
 
 import { ACCESS_CONTROL_BUNDLE_ID, makeDeltasBundleId, SNAPSHOTS_BUNDLE_ID } from '../../consts/special-file-ids.ts';
-import { APPLY_DELTAS_LIMIT_TIME_MSEC } from '../../consts/timing.ts';
+import { APPLY_DELTAS_LIMIT_TIME_MSEC, DOCUMENT_CACHE_DURATION_MSEC } from '../../consts/timing.ts';
 import { accessControlDocumentProvider } from '../../internal/context/accessControlDocument.ts';
 import { useIsSyncableValidationEnabled } from '../../internal/context/isSyncableValidationEnabled.ts';
 import type { ConflictFreeDocumentBundleNotifications } from '../../types/ConflictFreeDocumentBundleNotifications.ts';
@@ -26,16 +28,62 @@ import { getProvenanceOfSyncable } from './getProvenanceOfSyncable.ts';
 import { getStringFromFile } from './getStringFromFile.ts';
 import { getSyncableAtPath } from './getSyncableAtPath.ts';
 
+interface DocumentCacheValue {
+  numWatchers: number;
+  value: WatchableDocument<any>;
+  deleteFromCache: () => void;
+  deletionTimeout?: ReturnType<typeof setTimeout>;
+}
+
+const globalDocumentCache = new Map<string, Partial<Record<string, DocumentCacheValue>>>();
+
+const globalLockStore = new InMemoryLockStore();
+
+export const clearDocumentCache = () => {
+  for (const storeUid of globalDocumentCache.keys()) {
+    clearDocumentCacheForStore(storeUid);
+  }
+};
+
+export const clearDocumentCacheForStore = (storeUid: string) => {
+  const storeCache = globalDocumentCache.get(storeUid);
+  globalDocumentCache.delete(storeUid);
+
+  for (const value of objectValues(storeCache ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+
+    value.deleteFromCache();
+  }
+};
+
+export const deleteItemFromDocumentCache = (storeUid: string, path: SyncablePath) => {
+  const storeCache = globalDocumentCache.get(storeUid);
+  if (storeCache === undefined) {
+    return;
+  }
+
+  storeCache[path.toString()]?.deleteFromCache();
+};
+
 export interface GetConflictFreeDocumentFromBundleAtPathArgs {
   /**
-   * If `true`, the document will watch for new deltas added to the syncable store and automatically apply them.  If new snapshots are
-   * added, a `'needsReload'` notification will be triggered.
+   * If `true`, the document will watch for new snapshots and deltas added to the syncable store.  It will automatically apply deltas.  If
+   * new snapshots are added, a `'needsReload'` notification will be triggered.  The `stopWatching` method must be called when this
+   * document, or watching it, is no longer needed.  The document is also cached, where the cache duration will extend until at least
+   * `stopWatching` is called (at least once per returned instance) and may extended slightly longer.  Subsequent requests during the cached
+   * interval for the same path will return the same document instance.  `stopWatching` should be called for each instance however.
    *
-   * If `true`, the `stopWatching` method must be called when this document, or watching it, is no longer needed.
+   * If `false`, the document is loaded once and not watched or cached.
    *
-   * @defaultValue `false`
+   * If `'auto'`, this behaves like `watch = true`, except that the document is immediately unwatched.  The benefit of this is not having to
+   * call `stopWatching` but still getting reasonable caching behavior.  This just isn't great for user-time live documents -- for example
+   * where a user could be editing a document over an arbitrary amount of time.
+   *
+   * @defaultValue `'auto'`
    */
-  watch?: boolean;
+  watch?: boolean | 'auto';
 }
 
 export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
@@ -45,299 +93,387 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
     store: SyncableStore,
     path: SyncablePath,
     { loadDocument, isSnapshotValid, isDeltaValidForDocument }: ConflictFreeDocumentEvaluator<PrefixT, DocumentT>,
-    { watch = false }: GetConflictFreeDocumentFromBundleAtPathArgs = {}
+    { watch = 'auto' }: GetConflictFreeDocumentFromBundleAtPathArgs = {}
   ): PR<WatchableDocument<DocumentT>, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> => {
-    const isSyncableValidationEnabled = useIsSyncableValidationEnabled(trace).enabled;
-    const isAccessControlBundle = path.lastId === ACCESS_CONTROL_BUNDLE_ID;
+    const pathString = path.toString();
 
-    // Snapshots are encrypted if their parent bundle is encrypted
-    const areSnapshotsEncrypted = isSyncableItemEncrypted(path.lastId!);
+    // When watch = true, we only want one in-flight operation per path so that caching can be handled properly
+    const result = await withAcquiredLock(
+      trace,
+      globalLockStore.lock(watch !== false ? pathString : makeUuid()),
+      {},
+      async (trace): PR<WatchableDocument<DocumentT>, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> => {
+        let storeCache = watch !== false ? globalDocumentCache.get(store.uid) : undefined;
 
-    const notificationManager = new NotificationManager<ConflictFreeDocumentBundleNotifications>();
-    const onStopWatching: Array<() => void> = [];
-    const stopWatching = () => {
-      const toBeRemoved = [...onStopWatching];
-      onStopWatching.length = 0;
-      for (const removeListener of toBeRemoved) {
-        removeListener();
-      }
-    };
-
-    const snapshotsBundlePath = path.append(SNAPSHOTS_BUNDLE_ID({ encrypted: areSnapshotsEncrypted }));
-
-    // This function is replaced once the document is initially loaded
-    let getSnapshotId = (): string | undefined => undefined;
-
-    let applyDeltasToDocument:
-      | PRFunc<undefined, 'not-found' | 'deleted' | 'untrusted' | 'wrong-type' | 'format-error', [deltaPaths: SyncablePath[]]>
-      | undefined;
-
-    // TODO: this doesn't reevaluate permissions changes or previously rejected deltas etc
-    /** Will be set to `true` if a newer snapshot is added */
-    let needsReload = false;
-    let applyPendingDeltas = async () => {};
-    if (watch) {
-      const pendingDeltaPaths: SyncablePath[] = [];
-      const pendingDeltasTaskQueue = new TaskQueue(trace);
-      pendingDeltasTaskQueue.start({ maxConcurrency: 1, delayWhenEmptyMSec: APPLY_DELTAS_LIMIT_TIME_MSEC });
-      onStopWatching.push(() => pendingDeltasTaskQueue.stop());
-
-      const applyPendingDeltasNow = makeAsyncResultFunc([import.meta.filename, 'applyPendingDeltasNow'], async (trace): PR<undefined> => {
-        notificationManager.notify('willApplyDeltas', { path });
-
-        let numDeltasApplied = 0;
-        while (applyDeltasToDocument !== undefined && pendingDeltaPaths.length > 0) {
-          const deltaPaths = [...pendingDeltaPaths];
-          pendingDeltaPaths.length = 0;
-
-          const appliedDeltas = await applyDeltasToDocument?.(trace, deltaPaths);
-          if (!appliedDeltas.ok) {
-            return generalizeFailureResult(trace, appliedDeltas, ['deleted', 'format-error', 'not-found', 'untrusted', 'wrong-type']);
-          }
-          numDeltasApplied += deltaPaths.length;
-        }
-
-        notificationManager.notify('didApplyDeltas', { path, numDeltasApplied });
-
-        return makeSuccess(undefined);
-      });
-      applyPendingDeltas = async () => await pendingDeltasTaskQueue.wait();
-
-      onStopWatching.push(
-        store.addListener('itemAdded', (event) => {
-          const currentSnapshotId = getSnapshotId();
-          if (currentSnapshotId === undefined) {
-            return; // Not ready
+        if (watch !== false) {
+          if (storeCache === undefined) {
+            storeCache = {};
+            globalDocumentCache.set(store.uid, storeCache);
           }
 
-          if (event.path.startsWith(snapshotsBundlePath)) {
-            // If a newer snapshot was added, we need to reload the document
-
-            // Snapshot names are prefixed by ISO timestamps, so we can compare them lexicographically
-            if (!needsReload && event.path.ids[snapshotsBundlePath.ids.length] > currentSnapshotId) {
-              notificationManager.notify('needsReload', { path });
-              needsReload = true;
-            }
-          } else if (event.type === 'file') {
-            const currentSnapshotDeltasBundlePath = path.append(
-              makeDeltasBundleId({ encrypted: areSnapshotsEncrypted }, currentSnapshotId)
-            );
-
-            if (event.path.startsWith(currentSnapshotDeltasBundlePath)) {
-              pendingDeltaPaths.push(event.path);
-              pendingDeltasTaskQueue.add('apply-pending-deltas', applyPendingDeltasNow);
-            }
+          const cached = storeCache[pathString];
+          if (cached !== undefined) {
+            return makeSuccess(addWatcher(cached, watch));
           }
-        })
-      );
-    }
+        }
 
-    const docBundle = await getBundleAtPath(trace, store, path);
-    /* node:coverage disable */
-    if (!docBundle.ok) {
-      return docBundle;
-    }
-    /* node:coverage enable */
+        const isSyncableValidationEnabled = useIsSyncableValidationEnabled(trace).enabled;
+        const isAccessControlBundle = path.lastId === ACCESS_CONTROL_BUNDLE_ID;
 
-    const snapshots = await docBundle.value.get(trace, SNAPSHOTS_BUNDLE_ID({ encrypted: areSnapshotsEncrypted }), 'bundle');
-    /* node:coverage disable */
-    if (!snapshots.ok) {
-      return snapshots;
-    }
-    /* node:coverage enable */
+        // Snapshots are encrypted if their parent bundle is encrypted
+        const areSnapshotsEncrypted = isSyncableItemEncrypted(path.lastId!);
 
-    const snapshotIds = await snapshots.value.getIds(trace, { type: 'file' });
-    /* node:coverage disable */
-    if (!snapshotIds.ok) {
-      return snapshotIds;
-    } else if (snapshotIds.value.length === 0) {
-      /* node:coverage enable */
-      return makeFailure(new NotFoundError(trace, { message: `No snapshots found for: ${path.toString()}`, errorCode: 'not-found' }));
-    }
-
-    // TODO: should really try to load approved snapshots first and then not-yet-approved ones
-    // Snapshot names are prefixed by ISO timestamps, so sorting them will give us the most recent one last
-    snapshotIds.value.sort();
-
-    let snapshotIndex = snapshotIds.value.length - 1;
-    while (snapshotIndex >= 0) {
-      const snapshotId = snapshotIds.value[snapshotIndex];
-      snapshotIndex -= 1;
-
-      getSnapshotId = () => snapshotId;
-
-      const snapshotFile = await snapshots.value.get(trace, snapshotId, 'file');
-      if (!snapshotFile.ok) {
-        return snapshotFile;
-      }
-
-      const encodedSnapshot = await getStringFromFile(trace, store, snapshotFile.value);
-      /* node:coverage disable */
-      if (!encodedSnapshot.ok) {
-        return encodedSnapshot;
-      }
-      /* node:coverage enable */
-
-      let accessControlDoc: SyncableStoreAccessControlDocument | undefined;
-      if (isSyncableValidationEnabled) {
-        if (isAccessControlBundle) {
-          // Access control bundles are specially validated
-
-          accessControlDoc = new SyncableStoreAccessControlDocument({
-            snapshot: { id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<AccessControlDocumentPrefix> }
-          });
-        } else {
-          const foundAccessControlDoc = await getOwningAccessControlDocument(trace, store, path);
-          if (!foundAccessControlDoc.ok) {
-            return foundAccessControlDoc;
+        const notificationManager = new NotificationManager<ConflictFreeDocumentBundleNotifications>();
+        const onDeleteFromCache: Array<() => void> = [];
+        const deleteFromCache = () => {
+          const cached = storeCache![pathString];
+          if (cached !== undefined) {
+            clearTimeout(cached.deletionTimeout);
+            cached.deletionTimeout = undefined;
+            cached.value.stopWatching();
           }
 
-          accessControlDoc = foundAccessControlDoc.value;
-        }
-      }
+          delete storeCache![pathString];
 
-      // This is already validated when the file is retrieved
-      const snapshotProvenance = await getProvenanceOfSyncable(trace, store, snapshotFile.value);
-      if (!snapshotProvenance.ok) {
-        return snapshotProvenance;
-      }
+          const callbacks = [...onDeleteFromCache];
+          onDeleteFromCache.length = 0;
+          for (const callback of callbacks) {
+            callback();
+          }
+        };
 
-      const getOriginRole = () =>
-        getRoleForOrigin(trace, store, { origin: snapshotProvenance.value.origin, accessControlDoc: accessControlDoc! });
+        const snapshotsBundlePath = path.append(SNAPSHOTS_BUNDLE_ID({ encrypted: areSnapshotsEncrypted }));
 
-      // For not-yet-accepted values, performing additional checks
-      if (isSyncableValidationEnabled && !isAccessControlBundle && snapshotProvenance.value.acceptance === undefined) {
-        const originRole = await getOriginRole();
-        if (!originRole.ok) {
-          return generalizeFailureResult(trace, originRole, 'not-found');
-        } else if (originRole.value === undefined) {
-          // This shouldn't happen
-          return makeFailure(new ForbiddenError(trace, { message: 'No role found' }));
-        }
+        // This function is replaced once the document is initially loaded
+        let getSnapshotId = (): string | undefined => undefined;
 
-        const snapshotValid = await isSnapshotValid(trace, {
-          store,
-          path: snapshotFile.value.path,
-          validatedProvenance: snapshotProvenance.value,
-          originRole: originRole.value,
-          snapshot: { id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<PrefixT> }
-        });
-        if (!snapshotValid.ok) {
-          return snapshotValid;
-        } else if (!snapshotValid.value) {
-          DEV: debugTopic('VALIDATION', (log) => log(`Snapshot invalid for ${snapshotFile.value.path.toString()}`));
-          continue;
-        }
-      }
+        let applyDeltasToDocument:
+          | PRFunc<undefined, 'not-found' | 'deleted' | 'untrusted' | 'wrong-type' | 'format-error', [deltaPaths: SyncablePath[]]>
+          | undefined;
 
-      const document = (
-        isAccessControlBundle && accessControlDoc !== undefined
-          ? accessControlDoc
-          : loadDocument({ id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<PrefixT> })
-      ) as DocumentT;
+        // TODO: this doesn't reevaluate permissions changes or previously rejected deltas etc
+        /** Will be set to `true` if a newer snapshot is added */
+        let needsReload = false;
+        let applyPendingDeltas = async () => {};
+        if (watch !== false) {
+          const pendingDeltaPaths: SyncablePath[] = [];
+          const pendingDeltasTaskQueue = new TaskQueue(trace);
+          pendingDeltasTaskQueue.start({ maxConcurrency: 1, delayWhenEmptyMSec: APPLY_DELTAS_LIMIT_TIME_MSEC });
+          onDeleteFromCache.push(() => pendingDeltasTaskQueue.stop());
 
-      getSnapshotId = () => document.snapshotId;
+          const applyPendingDeltasNow = makeAsyncResultFunc(
+            [import.meta.filename, 'applyPendingDeltasNow'],
+            async (trace): PR<undefined> => {
+              notificationManager.notify('willApplyDeltas', { path });
 
-      applyDeltasToDocument = makeAsyncResultFunc(
-        [import.meta.filename, 'applyDeltasToDocument'],
-        async (trace, deltaPaths: SyncablePath[]): PR<undefined, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> => {
-          let numAppliedDeltas = 0;
-          for (const deltaPath of deltaPaths) {
-            // Using a potentially progressively loaded access control document for validating deltas.  If this bundle is itself an access
-            // control document, it will be progressively loaded as it's validated
-            const deltaFile = await accessControlDocumentProvider(trace, accessControlDoc, (trace) =>
-              getSyncableAtPath(trace, store, deltaPath, 'file')
-            );
-            if (!deltaFile.ok) {
-              return deltaFile;
-            }
+              let numDeltasApplied = 0;
+              while (applyDeltasToDocument !== undefined && pendingDeltaPaths.length > 0) {
+                const deltaPaths = [...pendingDeltaPaths];
+                pendingDeltaPaths.length = 0;
 
-            // This is already validated when the file is retrieved
-            const deltaProvenance = await getProvenanceOfSyncable(trace, store, deltaFile.value);
-            if (!deltaProvenance.ok) {
-              return deltaProvenance;
-            }
-
-            const encodedDelta = await getStringFromFile(trace, store, deltaFile.value);
-            if (!encodedDelta.ok) {
-              return encodedDelta;
-            }
-
-            // For not-yet-accepted values, performing additional checks
-            if (isSyncableValidationEnabled && deltaProvenance.value.acceptance === undefined) {
-              const originRole = await getOriginRole();
-              if (!originRole.ok) {
-                return generalizeFailureResult(trace, originRole, 'not-found');
-              } else if (originRole.value === undefined) {
-                // This shouldn't happen
-                return makeFailure(new ForbiddenError(trace, { message: 'No role found' }));
+                const appliedDeltas = await applyDeltasToDocument?.(trace, deltaPaths);
+                if (!appliedDeltas.ok) {
+                  return generalizeFailureResult(trace, appliedDeltas, ['deleted', 'format-error', 'not-found', 'untrusted', 'wrong-type']);
+                }
+                numDeltasApplied += deltaPaths.length;
               }
 
-              const deltaValid = await isDeltaValidForDocument(trace, document.clone() as DocumentT, {
-                store,
-                path: deltaFile.value.path,
-                validatedProvenance: deltaProvenance.value,
-                originRole: originRole.value,
-                encodedDelta: encodedDelta.value as EncodedConflictFreeDocumentDelta<PrefixT>
+              notificationManager.notify('didApplyDeltas', { path, numDeltasApplied });
+
+              return makeSuccess(undefined);
+            }
+          );
+          applyPendingDeltas = async () => await pendingDeltasTaskQueue.wait();
+
+          onDeleteFromCache.push(
+            store.addListener('itemAdded', (event) => {
+              const currentSnapshotId = getSnapshotId();
+              if (currentSnapshotId === undefined) {
+                return; // Not ready
+              }
+
+              if (event.path.startsWith(snapshotsBundlePath)) {
+                // If a newer snapshot was added, we need to reload the document
+
+                // Snapshot names are prefixed by ISO timestamps, so we can compare them lexicographically
+                if (!needsReload && event.path.ids[snapshotsBundlePath.ids.length] > currentSnapshotId) {
+                  notificationManager.notify('needsReload', { path });
+                  needsReload = true;
+                }
+              } else if (event.type === 'file') {
+                const currentSnapshotDeltasBundlePath = path.append(
+                  makeDeltasBundleId({ encrypted: areSnapshotsEncrypted }, currentSnapshotId)
+                );
+
+                if (event.path.startsWith(currentSnapshotDeltasBundlePath)) {
+                  pendingDeltaPaths.push(event.path);
+                  pendingDeltasTaskQueue.add('apply-pending-deltas', applyPendingDeltasNow);
+                }
+              }
+            })
+          );
+        }
+
+        const docBundle = await getBundleAtPath(trace, store, path);
+        /* node:coverage disable */
+        if (!docBundle.ok) {
+          return docBundle;
+        }
+        /* node:coverage enable */
+
+        const snapshots = await docBundle.value.get(trace, SNAPSHOTS_BUNDLE_ID({ encrypted: areSnapshotsEncrypted }), 'bundle');
+        /* node:coverage disable */
+        if (!snapshots.ok) {
+          return snapshots;
+        }
+        /* node:coverage enable */
+
+        const snapshotIds = await snapshots.value.getIds(trace, { type: 'file' });
+        /* node:coverage disable */
+        if (!snapshotIds.ok) {
+          return snapshotIds;
+        } else if (snapshotIds.value.length === 0) {
+          /* node:coverage enable */
+          return makeFailure(new NotFoundError(trace, { message: `No snapshots found for: ${pathString}`, errorCode: 'not-found' }));
+        }
+
+        // TODO: should really try to load approved snapshots first and then not-yet-approved ones
+        // Snapshot names are prefixed by ISO timestamps, so sorting them will give us the most recent one last
+        snapshotIds.value.sort();
+
+        let snapshotIndex = snapshotIds.value.length - 1;
+        while (snapshotIndex >= 0) {
+          const snapshotId = snapshotIds.value[snapshotIndex];
+          snapshotIndex -= 1;
+
+          getSnapshotId = () => snapshotId;
+
+          const snapshotFile = await snapshots.value.get(trace, snapshotId, 'file');
+          if (!snapshotFile.ok) {
+            return snapshotFile;
+          }
+
+          const encodedSnapshot = await getStringFromFile(trace, store, snapshotFile.value);
+          /* node:coverage disable */
+          if (!encodedSnapshot.ok) {
+            return encodedSnapshot;
+          }
+          /* node:coverage enable */
+
+          let accessControlDoc: SyncableStoreAccessControlDocument | undefined;
+          if (isSyncableValidationEnabled) {
+            if (isAccessControlBundle) {
+              // Access control bundles are specially validated
+
+              accessControlDoc = new SyncableStoreAccessControlDocument({
+                snapshot: {
+                  id: snapshotId,
+                  encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<AccessControlDocumentPrefix>
+                }
               });
-              if (!deltaValid.ok) {
-                return deltaValid;
-              } else if (!deltaValid.value) {
-                DEV: debugTopic('VALIDATION', (log) => log(`Delta invalid for ${deltaFile.value.path.toString()}`));
-                continue;
+            } else {
+              const foundAccessControlDoc = await getOwningAccessControlDocument(trace, store, path);
+              if (!foundAccessControlDoc.ok) {
+                return foundAccessControlDoc;
               }
+
+              accessControlDoc = foundAccessControlDoc.value;
+            }
+          }
+
+          // This is already validated when the file is retrieved
+          const snapshotProvenance = await getProvenanceOfSyncable(trace, store, snapshotFile.value);
+          if (!snapshotProvenance.ok) {
+            return snapshotProvenance;
+          }
+
+          const getOriginRole = () =>
+            getRoleForOrigin(trace, store, { origin: snapshotProvenance.value.origin, accessControlDoc: accessControlDoc! });
+
+          // For not-yet-accepted values, performing additional checks
+          if (isSyncableValidationEnabled && !isAccessControlBundle && snapshotProvenance.value.acceptance === undefined) {
+            const originRole = await getOriginRole();
+            if (!originRole.ok) {
+              return generalizeFailureResult(trace, originRole, 'not-found');
+            } else if (originRole.value === undefined) {
+              // This shouldn't happen
+              return makeFailure(new ForbiddenError(trace, { message: 'No role found' }));
             }
 
-            // If this is an access control bundle, this is also how it will progressively load
-            document.applyDeltas([encodedDelta.value as EncodedConflictFreeDocumentDelta<PrefixT>], { updateDeltaBasis: false });
-            numAppliedDeltas += 1;
+            const snapshotValid = await isSnapshotValid(trace, {
+              store,
+              path: snapshotFile.value.path,
+              validatedProvenance: snapshotProvenance.value,
+              originRole: originRole.value,
+              snapshot: { id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<PrefixT> }
+            });
+            if (!snapshotValid.ok) {
+              return snapshotValid;
+            } else if (!snapshotValid.value) {
+              DEV: debugTopic('VALIDATION', (log) => log(`Snapshot invalid for ${snapshotFile.value.path.toString()}`));
+              continue;
+            }
           }
 
-          if (numAppliedDeltas > 0) {
-            document.updateDeltaBasis();
+          const document = (
+            isAccessControlBundle && accessControlDoc !== undefined
+              ? accessControlDoc
+              : loadDocument({ id: snapshotId, encoded: encodedSnapshot.value as EncodedConflictFreeDocumentSnapshot<PrefixT> })
+          ) as DocumentT;
+
+          getSnapshotId = () => document.snapshotId;
+
+          applyDeltasToDocument = makeAsyncResultFunc(
+            [import.meta.filename, 'applyDeltasToDocument'],
+            async (
+              trace,
+              deltaPaths: SyncablePath[]
+            ): PR<undefined, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> => {
+              let numAppliedDeltas = 0;
+              for (const deltaPath of deltaPaths) {
+                // Using a potentially progressively loaded access control document for validating deltas.  If this bundle is itself an access
+                // control document, it will be progressively loaded as it's validated
+                const deltaFile = await accessControlDocumentProvider(trace, accessControlDoc, (trace) =>
+                  getSyncableAtPath(trace, store, deltaPath, 'file')
+                );
+                if (!deltaFile.ok) {
+                  return deltaFile;
+                }
+
+                // This is already validated when the file is retrieved
+                const deltaProvenance = await getProvenanceOfSyncable(trace, store, deltaFile.value);
+                if (!deltaProvenance.ok) {
+                  return deltaProvenance;
+                }
+
+                const encodedDelta = await getStringFromFile(trace, store, deltaFile.value);
+                if (!encodedDelta.ok) {
+                  return encodedDelta;
+                }
+
+                // For not-yet-accepted values, performing additional checks
+                if (isSyncableValidationEnabled && deltaProvenance.value.acceptance === undefined) {
+                  const originRole = await getOriginRole();
+                  if (!originRole.ok) {
+                    return generalizeFailureResult(trace, originRole, 'not-found');
+                  } else if (originRole.value === undefined) {
+                    // This shouldn't happen
+                    return makeFailure(new ForbiddenError(trace, { message: 'No role found' }));
+                  }
+
+                  const deltaValid = await isDeltaValidForDocument(trace, document.clone() as DocumentT, {
+                    store,
+                    path: deltaFile.value.path,
+                    validatedProvenance: deltaProvenance.value,
+                    originRole: originRole.value,
+                    encodedDelta: encodedDelta.value as EncodedConflictFreeDocumentDelta<PrefixT>
+                  });
+                  if (!deltaValid.ok) {
+                    return deltaValid;
+                  } else if (!deltaValid.value) {
+                    DEV: debugTopic('VALIDATION', (log) => log(`Delta invalid for ${deltaFile.value.path.toString()}`));
+                    continue;
+                  }
+                }
+
+                // If this is an access control bundle, this is also how it will progressively load
+                document.applyDeltas([encodedDelta.value as EncodedConflictFreeDocumentDelta<PrefixT>], { updateDeltaBasis: false });
+                numAppliedDeltas += 1;
+              }
+
+              if (numAppliedDeltas > 0) {
+                document.updateDeltaBasis();
+              }
+
+              return makeSuccess(undefined);
+            }
+          );
+
+          // Deltas are encrypted if their parent bundle is encrypted
+          const areDeltaEncrypted = isSyncableItemEncrypted(path.lastId!);
+          const deltas = await docBundle.value.get(trace, makeDeltasBundleId({ encrypted: areDeltaEncrypted }, snapshotId), 'bundle');
+          /* node:coverage disable */
+          if (!deltas.ok) {
+            return deltas;
+          }
+          /* node:coverage enable */
+
+          const deltaIds = await deltas.value.getIds(trace, { type: 'file' });
+          /* node:coverage disable */
+          if (!deltaIds.ok) {
+            return deltaIds;
+          }
+          /* node:coverage enable */
+
+          // TODO: should really try to load approved deltas first and then not-yet-approved ones
+          // Delta names are prefixed by ISO timestamps, so sorting them will give us the most recent one last
+          deltaIds.value.sort();
+
+          const deltaPaths = deltaIds.value.map((id) => deltas.value.path.append(id));
+          const appliedDeltas = await applyDeltasToDocument(trace, deltaPaths);
+          if (!appliedDeltas.ok) {
+            return appliedDeltas;
           }
 
-          return makeSuccess(undefined);
+          const watchableDocument: WatchableDocument<DocumentT> = {
+            document,
+            addListener: notificationManager.addListener,
+            get needsReload() {
+              return needsReload;
+            },
+            applyPendingDeltas,
+            stopWatching: () => {} // Replaced before returning, when watch is true
+          };
+
+          if (watch !== false) {
+            const cached: DocumentCacheValue = { numWatchers: 0, deleteFromCache, value: watchableDocument };
+
+            storeCache![pathString] = cached;
+
+            return makeSuccess(addWatcher(cached, watch));
+          }
+
+          return makeSuccess(watchableDocument);
         }
-      );
 
-      // Deltas are encrypted if their parent bundle is encrypted
-      const areDeltaEncrypted = isSyncableItemEncrypted(path.lastId!);
-      const deltas = await docBundle.value.get(trace, makeDeltasBundleId({ encrypted: areDeltaEncrypted }, snapshotId), 'bundle');
-      /* node:coverage disable */
-      if (!deltas.ok) {
-        return deltas;
+        return makeFailure(
+          new NotFoundError(trace, { message: `No valid snapshots found for: ${path.toString()}`, errorCode: 'not-found' })
+        );
       }
-      /* node:coverage enable */
-
-      const deltaIds = await deltas.value.getIds(trace, { type: 'file' });
-      /* node:coverage disable */
-      if (!deltaIds.ok) {
-        return deltaIds;
-      }
-      /* node:coverage enable */
-
-      // TODO: should really try to load approved deltas first and then not-yet-approved ones
-      // Delta names are prefixed by ISO timestamps, so sorting them will give us the most recent one last
-      deltaIds.value.sort();
-
-      const deltaPaths = deltaIds.value.map((id) => deltas.value.path.append(id));
-      const appliedDeltas = await applyDeltasToDocument(trace, deltaPaths);
-      if (!appliedDeltas.ok) {
-        return appliedDeltas;
-      }
-
-      return makeSuccess({
-        document,
-        addListener: notificationManager.addListener,
-        get needsReload() {
-          return needsReload;
-        },
-        applyPendingDeltas,
-        stopWatching
-      });
+    );
+    if (!result.ok) {
+      return generalizeFailureResult(trace, result, 'lock-timeout');
     }
 
-    return makeFailure(new NotFoundError(trace, { message: `No valid snapshots found for: ${path.toString()}`, errorCode: 'not-found' }));
+    return makeSuccess(result.value);
   }
 );
+
+// Helpers
+
+const addWatcher = (cached: DocumentCacheValue, watch: true | 'auto') => {
+  clearTimeout(cached.deletionTimeout);
+  cached.deletionTimeout = undefined;
+
+  cached.numWatchers += 1;
+
+  let didStopWatching = false;
+  const stopWatching = () => {
+    if (didStopWatching) {
+      return;
+    }
+    didStopWatching = true;
+
+    cached.numWatchers -= 1;
+
+    if (cached.numWatchers === 0) {
+      cached.deletionTimeout = setTimeout(cached.deleteFromCache, DOCUMENT_CACHE_DURATION_MSEC);
+    }
+  };
+
+  if (watch === 'auto') {
+    stopWatching();
+  }
+
+  return { ...cached.value, stopWatching };
+};


### PR DESCRIPTION
- When watch=true on getConflictFreeDocumentFromBundleAtPath and similar now, the document is cached until 30 seconds after the last watcher calls stopWatching (and the timer is canceled if another watcher is added in the meantime)
- The watch option on getConflictFreeDocumentFromBundleAtPath and similar now supports an 'auto' value, which behaves like watch=true but then immediately stops watching
- The default value for watch is now "auto"
- SyncableStores now have a uid field, which is convenient for ensuring global caches are unique, for example
- test suites that use conflict free documents with SyncableStores should generally call `afterEach(clearDocumentCache)` since otherwise it'll wait 30 seconds to move to the next suite (since it waits for pending timeouts)