### PR TITLE
Mail Storage Traversal

### DIFF
--- a/code/cross-platform-packages/freedom-email-sync/package.json
+++ b/code/cross-platform-packages/freedom-email-sync/package.json
@@ -3,6 +3,7 @@
     "freedom-async": "0.0.0",
     "freedom-basic-data": "0.0.0",
     "freedom-common-errors": "0.0.0",
+    "freedom-contexts": "0.0.0",
     "freedom-crypto-service": "0.0.0",
     "freedom-nest": "0.0.0",
     "freedom-paginated-data": "0.0.0",
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@types/luxon": "3.6.2",
     "freedom-build-tools": "0.0.0",
+    "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"
   },
   "type": "module",
@@ -38,7 +40,7 @@
     "test": "yarn test:unit-tests",
     "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
-    "test:unit-tests": "echo tests-disabled # NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
+    "test:unit-tests": "NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
     "deploy:extract": "../../poc/repo/deploy.extract.sh"
   },
   "types": "lib/exports.d.ts",

--- a/code/cross-platform-packages/freedom-email-sync/src/internal/utils/__tests__/extractNumberFromPlainSyncableId.test.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/internal/utils/__tests__/extractNumberFromPlainSyncableId.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'node:test';
+
+import { plainId } from 'freedom-sync-types';
+import { expectStrictEqual } from 'freedom-testing-tools';
+
+import { extractNumberFromPlainSyncableId } from '../extractNumberFromPlainSyncableId.ts';
+
+describe('extractNumberFromPlainSyncableId', () => {
+  it('should work', () => {
+    expectStrictEqual(extractNumberFromPlainSyncableId(plainId('bundle', '2025')), 2025);
+  });
+});

--- a/code/cross-platform-packages/freedom-email-sync/src/internal/utils/extractNumberFromPlainSyncableId.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/internal/utils/extractNumberFromPlainSyncableId.ts
@@ -1,0 +1,16 @@
+import type { SyncableId } from 'freedom-sync-types';
+import { extractUnmarkedSyncableId, unmarkedSyncablePlainIdInfo } from 'freedom-sync-types';
+
+export const extractNumberFromPlainSyncableId = (syncableId: SyncableId): number | undefined => {
+  const unmarkedId = extractUnmarkedSyncableId(syncableId);
+
+  const unmarkedPlainId = unmarkedSyncablePlainIdInfo.checked(unmarkedId);
+  if (unmarkedPlainId === undefined) {
+    return undefined;
+  }
+
+  const plainIdWithoutPrefix = unmarkedSyncablePlainIdInfo.removePrefix(unmarkedPlainId);
+
+  const numeric = Number(plainIdWithoutPrefix);
+  return Number.isInteger(numeric) ? numeric : undefined;
+};

--- a/code/cross-platform-packages/freedom-email-sync/src/utils/addMail.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/utils/addMail.ts
@@ -1,6 +1,8 @@
 import type { PR } from 'freedom-async';
 import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { makeIsoDateTime } from 'freedom-basic-data';
 import { generalizeFailureResult } from 'freedom-common-errors';
+import { makeUuid } from 'freedom-contexts';
 import { createJsonFileAtPath, getOrCreateBundlesAtPaths } from 'freedom-syncable-store';
 
 import type { EmailAccess } from '../types/EmailAccess.ts';
@@ -14,7 +16,7 @@ export const addMail = makeAsyncResultFunc(
     const userFs = access.userFs;
     const paths = await getMailPaths(userFs);
 
-    const mailId = mailIdInfo.make();
+    const mailId = mailIdInfo.make(`${makeIsoDateTime(new Date(mail.timeMSec))}-${makeUuid()}`);
     const mailDate = new Date(mailIdInfo.extractTimeMSec(mailId));
 
     const storageYearPath = paths.storage.year(mailDate);

--- a/code/cross-platform-packages/freedom-email-sync/src/utils/exports.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/utils/exports.ts
@@ -4,4 +4,6 @@ export * from './getMailPaths.ts';
 export * from './getOutboundMailById.ts';
 export * from './listOutboundMailIds.ts';
 export * from './listTimeOrganizedMailIds.ts';
+export * from './makeBottomUpTimeOrganizedMailStorageTraverser.ts';
 export * from './moveOutboundMailToStorage.ts';
+export * from './traverseTimeOrganizedMailStorageFromTheBottomUp.ts';

--- a/code/cross-platform-packages/freedom-email-sync/src/utils/makeBottomUpTimeOrganizedMailStorageTraverser.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/utils/makeBottomUpTimeOrganizedMailStorageTraverser.ts
@@ -1,0 +1,325 @@
+import type { PR, PRFunc } from 'freedom-async';
+import { excludeFailureResult, makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import { syncableItemTypes } from 'freedom-sync-types';
+import { getSyncableAtPath } from 'freedom-syncable-store';
+import { DateTime } from 'luxon';
+
+import { extractNumberFromPlainSyncableId } from '../internal/utils/extractNumberFromPlainSyncableId.ts';
+import type { EmailAccess } from '../types/EmailAccess.ts';
+import type { TimeOrganizedMailStorage } from './getMailPaths.ts';
+
+export interface TimeUnitValue {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+}
+
+export interface TimeOrganizedMailStorageYearValue {
+  type: 'year';
+  value: Partial<TimeUnitValue> & { year: number };
+}
+
+export interface TimeOrganizedMailStorageMonthValue {
+  type: 'month';
+  value: Partial<TimeUnitValue> & { year: number; month: number };
+}
+
+export interface TimeOrganizedMailStorageDayValue {
+  type: 'day';
+  value: Partial<TimeUnitValue> & { year: number; month: number; day: number };
+}
+
+export interface TimeOrganizedMailStorageHourValue {
+  type: 'hour';
+  value: TimeUnitValue;
+}
+
+export type TimeOrganizedMailStorageUnitValue =
+  | TimeOrganizedMailStorageYearValue
+  | TimeOrganizedMailStorageMonthValue
+  | TimeOrganizedMailStorageDayValue
+  | TimeOrganizedMailStorageHourValue;
+
+export type TimeOrganizedMailStorageTraverserAccessor = TimeOrganizedMailStorageUnitValue & {
+  previous: PRFunc<TimeOrganizedMailStorageTraverserAccessor | undefined>;
+  inside: PRFunc<TimeOrganizedMailStorageTraverserAccessor | undefined>;
+};
+
+/**
+ * Returns the newest year with content and then provides methods for:
+ * - getting the previous year with content
+ * - getting the newest month with content in that year
+ *
+ * and recursively the same for month, day and hour.
+ *
+ * If there is no content, it returns `undefined`.
+ */
+export const makeBottomUpTimeOrganizedMailStorageTraverser = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    access: EmailAccess,
+    {
+      timeOrganizedMailStorage,
+      offset
+    }: { timeOrganizedMailStorage: TimeOrganizedMailStorage; offset?: TimeOrganizedMailStorageUnitValue['value'] }
+  ): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
+    const userFs = access.userFs;
+
+    const offsetYear = offset?.year;
+    const offsetMonth = offset?.month;
+    const offsetDay = offset?.day;
+    const offsetHour = offset?.hour;
+
+    const getSameOrPreviousYear = makeAsyncResultFunc(
+      [import.meta.filename, 'getSameOrPreviousYear'],
+      async (trace, cursorYear: number): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
+        const baseFolderLike = await getSyncableAtPath(trace, userFs, timeOrganizedMailStorage.value, syncableItemTypes.exclude('file'));
+        if (!baseFolderLike.ok) {
+          if (baseFolderLike.value.errorCode === 'deleted' || baseFolderLike.value.errorCode === 'not-found') {
+            return makeSuccess(undefined);
+          }
+
+          return generalizeFailureResult(trace, excludeFailureResult(baseFolderLike, 'deleted', 'not-found'), ['untrusted', 'wrong-type']);
+        }
+
+        const syncableIdsInBase = await baseFolderLike.value.getIds(trace, { type: 'bundle' });
+        if (!syncableIdsInBase.ok) {
+          return syncableIdsInBase;
+        }
+
+        const sameOrPreviousYearWithContent = syncableIdsInBase.value
+          .map((syncableId) => {
+            const year = extractNumberFromPlainSyncableId(syncableId);
+            if (year !== undefined && year >= 0 && year <= cursorYear) {
+              return year;
+            } else {
+              return undefined;
+            }
+          })
+          .filter((v) => v !== undefined)
+          .sort((a, b) => b - a)[0];
+        if (sameOrPreviousYearWithContent === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        return makeSuccess({
+          type: 'year' as const,
+          value: { year: sameOrPreviousYearWithContent },
+          previous: makeAsyncResultFunc(
+            [import.meta.filename, 'getSameOrPreviousYear', 'previous'],
+            async (trace) => await getSameOrPreviousYear(trace, sameOrPreviousYearWithContent - 1)
+          ),
+          inside: makeAsyncResultFunc([import.meta.filename, 'getSameOrPreviousYear', 'inside'], async (trace) => {
+            const endOfYear = DateTime.fromObject({ year: sameOrPreviousYearWithContent }, { zone: 'UTC' }).endOf('year');
+            return await getSameOrPreviousMonth(trace, sameOrPreviousYearWithContent, endOfYear.month);
+          })
+        });
+      }
+    );
+
+    const getSameOrPreviousMonth = makeAsyncResultFunc(
+      [import.meta.filename, 'getSameOrPreviousMonth'],
+      async (trace, cursorYear: number, cursorMonth: number): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
+        if (cursorMonth <= 0) {
+          return makeSuccess(undefined);
+        }
+
+        const baseYearPath = timeOrganizedMailStorage.year(makeDate(cursorYear, 1, 1, 0));
+        const yearPath = baseYearPath.value;
+
+        const yearBundle = await getSyncableAtPath(trace, userFs, yearPath, 'bundle');
+        if (!yearBundle.ok) {
+          if (yearBundle.value.errorCode === 'deleted' || yearBundle.value.errorCode === 'not-found') {
+            return makeSuccess(undefined);
+          }
+
+          return generalizeFailureResult(trace, excludeFailureResult(yearBundle, 'deleted', 'not-found'), ['untrusted', 'wrong-type']);
+        }
+
+        const syncableIdsInYear = await yearBundle.value.getIds(trace, { type: 'bundle' });
+        if (!syncableIdsInYear.ok) {
+          return syncableIdsInYear;
+        }
+
+        const sameOrPreviousMonthWithContent = syncableIdsInYear.value
+          .map((syncableId) => {
+            const month = extractNumberFromPlainSyncableId(syncableId);
+            if (
+              month !== undefined &&
+              month >= 0 &&
+              month <= cursorMonth &&
+              (cursorYear !== offsetYear || offsetMonth === undefined || month <= offsetMonth)
+            ) {
+              return month;
+            } else {
+              return undefined;
+            }
+          })
+          .filter((v) => v !== undefined)
+          .sort((a, b) => b - a)[0];
+        if (sameOrPreviousMonthWithContent === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        return makeSuccess({
+          type: 'month' as const,
+          value: { year: cursorYear, month: sameOrPreviousMonthWithContent },
+          previous: makeAsyncResultFunc(
+            [import.meta.filename, 'getSameOrPreviousMonth', 'previous'],
+            async (trace) => await getSameOrPreviousMonth(trace, cursorYear, sameOrPreviousMonthWithContent - 1)
+          ),
+          inside: makeAsyncResultFunc([import.meta.filename, 'getSameOrPreviousMonth', 'inside'], async (trace) => {
+            const endOfMonth = DateTime.fromObject({ year: cursorYear, month: sameOrPreviousMonthWithContent }, { zone: 'UTC' }).endOf(
+              'month'
+            );
+            return await getSameOrPreviousDay(trace, cursorYear, sameOrPreviousMonthWithContent, endOfMonth.day);
+          })
+        });
+      }
+    );
+
+    const getSameOrPreviousDay = makeAsyncResultFunc(
+      [import.meta.filename, 'getSameOrPreviousDay'],
+      async (
+        trace,
+        cursorYear: number,
+        cursorMonth: number,
+        cursorDay: number
+      ): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
+        if (cursorDay <= 0) {
+          return makeSuccess(undefined);
+        }
+
+        const baseYearPath = timeOrganizedMailStorage.year(makeDate(cursorYear, cursorMonth, 1, 0));
+        const monthPath = baseYearPath.month.value;
+
+        const monthBundle = await getSyncableAtPath(trace, userFs, monthPath, 'bundle');
+        if (!monthBundle.ok) {
+          if (monthBundle.value.errorCode === 'deleted' || monthBundle.value.errorCode === 'not-found') {
+            return makeSuccess(undefined);
+          }
+
+          return generalizeFailureResult(trace, excludeFailureResult(monthBundle, 'deleted', 'not-found'), ['untrusted', 'wrong-type']);
+        }
+
+        const syncableIdsInMonth = await monthBundle.value.getIds(trace, { type: 'bundle' });
+        if (!syncableIdsInMonth.ok) {
+          return syncableIdsInMonth;
+        }
+
+        const sameOrPreviousDayWithContent = syncableIdsInMonth.value
+          .map((syncableId) => {
+            const day = extractNumberFromPlainSyncableId(syncableId);
+            if (
+              day !== undefined &&
+              day >= 0 &&
+              day <= cursorDay &&
+              (cursorYear !== offsetYear || cursorMonth !== offsetMonth || offsetDay === undefined || day <= offsetDay)
+            ) {
+              return day;
+            } else {
+              return undefined;
+            }
+          })
+          .filter((v) => v !== undefined)
+          .sort((a, b) => b - a)[0];
+        if (sameOrPreviousDayWithContent === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        return makeSuccess({
+          type: 'day' as const,
+          value: { year: cursorYear, month: cursorMonth, day: sameOrPreviousDayWithContent },
+          previous: makeAsyncResultFunc(
+            [import.meta.filename, 'getSameOrPreviousDay', 'previous'],
+            async (trace) => await getSameOrPreviousDay(trace, cursorYear, cursorMonth, sameOrPreviousDayWithContent - 1)
+          ),
+          inside: makeAsyncResultFunc([import.meta.filename, 'getSameOrPreviousDay', 'inside'], async (trace) => {
+            const endOfDay = DateTime.fromObject(
+              { year: cursorYear, month: cursorMonth, day: sameOrPreviousDayWithContent },
+              { zone: 'UTC' }
+            ).endOf('day');
+            return await getSameOrPreviousHour(trace, cursorYear, cursorMonth, sameOrPreviousDayWithContent, endOfDay.hour);
+          })
+        });
+      }
+    );
+
+    const getSameOrPreviousHour = makeAsyncResultFunc(
+      [import.meta.filename, 'getSameOrPreviousHour'],
+      async (
+        trace,
+        cursorYear: number,
+        cursorMonth: number,
+        cursorDay: number,
+        cursorHour: number
+      ): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
+        if (cursorHour < 0) {
+          return makeSuccess(undefined);
+        }
+
+        const baseYearPath = timeOrganizedMailStorage.year(makeDate(cursorYear, cursorMonth, cursorDay, 0));
+        const dayPath = baseYearPath.month.day.value;
+
+        const dayBundle = await getSyncableAtPath(trace, userFs, dayPath, 'bundle');
+        if (!dayBundle.ok) {
+          if (dayBundle.value.errorCode === 'deleted' || dayBundle.value.errorCode === 'not-found') {
+            return makeSuccess(undefined);
+          }
+
+          return generalizeFailureResult(trace, excludeFailureResult(dayBundle, 'deleted', 'not-found'), ['untrusted', 'wrong-type']);
+        }
+
+        const syncableIdsInDay = await dayBundle.value.getIds(trace, { type: 'bundle' });
+        if (!syncableIdsInDay.ok) {
+          return syncableIdsInDay;
+        }
+
+        const sameOrPreviousHourWithContent = syncableIdsInDay.value
+          .map((syncableId) => {
+            const hour = extractNumberFromPlainSyncableId(syncableId);
+            if (
+              hour !== undefined &&
+              hour >= 0 &&
+              hour <= cursorHour &&
+              (cursorYear !== offsetYear ||
+                cursorMonth !== offsetMonth ||
+                cursorDay !== offsetDay ||
+                offsetHour === undefined ||
+                hour <= offsetHour)
+            ) {
+              return hour;
+            } else {
+              return undefined;
+            }
+          })
+          .filter((v) => v !== undefined)
+          .sort((a, b) => b - a)[0];
+        if (sameOrPreviousHourWithContent === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        return makeSuccess({
+          type: 'hour' as const,
+          value: { year: cursorYear, month: cursorMonth, day: cursorDay, hour: sameOrPreviousHourWithContent },
+          previous: makeAsyncResultFunc(
+            [import.meta.filename, 'getSameOrPreviousHour', 'previous'],
+            async (trace) => await getSameOrPreviousHour(trace, cursorYear, cursorMonth, cursorDay, sameOrPreviousHourWithContent - 1)
+          ),
+          inside: makeAsyncResultFunc([import.meta.filename, 'getSameOrPreviousHour', 'inside'], async (_trace) => makeSuccess(undefined))
+        });
+      }
+    );
+
+    return await getSameOrPreviousYear(trace, offsetYear ?? new Date().getUTCFullYear());
+  }
+);
+
+// Helpers
+
+const makeDate = (year: number, month: number, date: number, hour: number): Date => {
+  return new Date(`${year}-${String(month).padStart(2, '0')}-${String(date).padStart(2, '0')}T${String(hour).padStart(2, '0')}:00:00Z`);
+};

--- a/code/cross-platform-packages/freedom-email-sync/src/utils/traverseTimeOrganizedMailStorageFromTheBottomUp.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/utils/traverseTimeOrganizedMailStorageFromTheBottomUp.ts
@@ -1,0 +1,130 @@
+import type { PR, PRFunc } from 'freedom-async';
+import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
+
+import type { EmailAccess } from '../types/EmailAccess.ts';
+import type { TimeOrganizedMailStorage } from './getMailPaths.ts';
+import type {
+  TimeOrganizedMailStorageTraverserAccessor,
+  TimeOrganizedMailStorageUnitValue
+} from './makeBottomUpTimeOrganizedMailStorageTraverser.ts';
+import { makeBottomUpTimeOrganizedMailStorageTraverser } from './makeBottomUpTimeOrganizedMailStorageTraverser.ts';
+
+export type BottomUpMailStorageTraversalResult = 'inspect' | 'skip' | 'stop';
+
+export type BottomUpMailStorageTraversalCallback = PRFunc<
+  BottomUpMailStorageTraversalResult,
+  never,
+  [cursor: TimeOrganizedMailStorageTraverserAccessor]
+>;
+
+/**
+ * Traverses the specified time-organized mail storage from the bottom up, starting with the newest year.  For each year with content, the
+ * specified callback is called.  The callback can choose, by returning, to:
+ * - stop – stops the traversal
+ * - skip - skips the current year and moves on to the previous year
+ * - inspect - begins calling the callback with the months of the current year, in descending order
+ *
+ * This works recursively for year, month, day, and hour.  Returning `'skip'` or `'inspect'` on `hour` items is the same, since hours don't have
+ * sub-contents.
+ */
+export const traverseTimeOrganizedMailStorageFromTheBottomUp = makeAsyncResultFunc(
+  [import.meta.filename],
+  async (
+    trace,
+    access: EmailAccess,
+    {
+      timeOrganizedMailStorage,
+      offset
+    }: { timeOrganizedMailStorage: TimeOrganizedMailStorage; offset?: TimeOrganizedMailStorageUnitValue['value'] },
+    callback: BottomUpMailStorageTraversalCallback
+  ): PR<undefined> => {
+    const cursor = await makeBottomUpTimeOrganizedMailStorageTraverser(trace, access, { timeOrganizedMailStorage, offset });
+    if (!cursor.ok) {
+      return cursor;
+    }
+
+    const handledLevel = await handleLevel(trace, cursor.value, { offset }, callback);
+    if (!handledLevel.ok) {
+      return handledLevel;
+    }
+
+    return makeSuccess(undefined);
+  }
+);
+
+// Helpers
+
+const handleLevel = makeAsyncResultFunc(
+  [import.meta.filename, 'handleLevel'],
+  async (
+    trace,
+    cursor: TimeOrganizedMailStorageTraverserAccessor | undefined,
+    { offset }: { offset: TimeOrganizedMailStorageUnitValue['value'] | undefined },
+    callback: BottomUpMailStorageTraversalCallback
+  ): PR<'stop' | undefined> => {
+    while (cursor !== undefined) {
+      const result = shouldIgnoreForOffset(cursor.value, offset) ? makeSuccess('inspect' as const) : await callback(trace, cursor);
+      if (!result.ok) {
+        return result;
+      }
+
+      switch (result.value) {
+        case 'stop':
+          return makeSuccess('stop' as const);
+        case 'inspect': {
+          const nextLevel = await cursor.inside(trace);
+          if (!nextLevel.ok) {
+            return nextLevel;
+          }
+
+          const handledLevel = await handleLevel(trace, nextLevel.value, { offset }, callback);
+          if (!handledLevel.ok) {
+            return handledLevel;
+          } else if (handledLevel.value === 'stop') {
+            return makeSuccess('stop' as const);
+          }
+
+          break;
+        }
+        case 'skip':
+          // Nothing to do
+          break;
+      }
+
+      const previous = await cursor.previous(trace);
+      if (!previous.ok) {
+        return previous;
+      }
+
+      cursor = previous.value;
+    }
+
+    return makeSuccess(undefined);
+  }
+);
+
+const shouldIgnoreForOffset = (
+  cursor: TimeOrganizedMailStorageTraverserAccessor['value'],
+  offset: TimeOrganizedMailStorageUnitValue['value'] | undefined
+): boolean => {
+  if (offset === undefined) {
+    return false;
+  }
+
+  if (offset.hour !== undefined) {
+    return (
+      (cursor.year === offset.year && cursor.month === offset.month && cursor.day === offset.day && cursor.hour === undefined) ||
+      (cursor.year === offset.year && cursor.month === offset.month && cursor.day === undefined) ||
+      (cursor.year === offset.year && cursor.month === undefined)
+    );
+  } else if (offset.day !== undefined) {
+    return (
+      (cursor.year === offset.year && cursor.month === offset.month && cursor.day === undefined) ||
+      (cursor.year === offset.year && cursor.month === undefined)
+    );
+  } else if (offset.month !== undefined) {
+    return cursor.year === offset.year && cursor.month === undefined;
+  }
+
+  return false;
+};

--- a/code/cross-platform-packages/freedom-email-user/package.json
+++ b/code/cross-platform-packages/freedom-email-user/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "freedom-build-tools": "0.0.0",
+    "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"
   },
   "type": "module",
@@ -42,7 +43,7 @@
     "test": "yarn test:unit-tests",
     "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
     "test:perf": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_PROFILE=${FREEDOM_PROFILE:-all} FREEDOM_LOG_FUNCS=${FREEDOM_LOG_FUNCS:-} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",
-    "test:unit-tests": "echo tests-disabled # NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
+    "test:unit-tests": "NODE_OPTIONS='--experimental-transform-types  --disable-warning=ExperimentalWarning' node --experimental-test-module-mocks --experimental-test-coverage --test-coverage-include='src/**/*' --test-coverage-exclude='src/**/**.test.ts' --test-concurrency=1 --test-coverage-branches=80 --test-coverage-functions=80 --test-coverage-lines=90 --test-timeout=300000 --test",
     "deploy:extract": "../../poc/repo/deploy.extract.sh"
   },
   "types": "lib/exports.d.ts",

--- a/code/cross-platform-packages/freedom-email-user/src/__tests__/scenarios.test.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/__tests__/scenarios.test.ts
@@ -1,13 +1,15 @@
 import { strict as assert } from 'node:assert';
-import { describe, test } from 'node:test';
+import { afterEach, describe, test } from 'node:test';
 
 import { listOutboundMailIds } from 'freedom-email-sync';
-import { createBundleAtPath, createFolderAtPath } from 'freedom-syncable-store';
+import { clearDocumentCache, createBundleAtPath, createFolderAtPath } from 'freedom-syncable-store';
 
 import { createEmailStoreTestStack } from '../__test_dependency__/createEmailStoreTestStack.ts';
 import { addMailDraft, getMailDraftById, getUserMailPaths, moveMailDraftToOutbox } from '../utils/exports.ts';
 
 describe('Outbound email routes', () => {
+  afterEach(clearDocumentCache);
+
   test('Full external address outbound', async () => {
     // Arrange
     const { trace, store, access } = await createEmailStoreTestStack();
@@ -15,8 +17,8 @@ describe('Outbound email routes', () => {
     const paths = await getUserMailPaths(store);
 
     // Mail Storage Folder
-    const mailStorageBundle = await createFolderAtPath(trace, store, paths.storage.value);
-    assert.ok(mailStorageBundle.ok);
+    const mailStorageFolder = await createFolderAtPath(trace, store, paths.storage.value);
+    assert.ok(mailStorageFolder.ok);
 
     // Mail Out Folder
     const mailOutFolder = await createFolderAtPath(trace, store, paths.out.value);

--- a/code/cross-platform-packages/freedom-email-user/src/__tests__/traverseTimeOrganizedMailStorageFromTheBottomUp.test.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/__tests__/traverseTimeOrganizedMailStorageFromTheBottomUp.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, describe, it } from 'node:test';
+
+import { makeSuccess, type PR } from 'freedom-async';
+import type { BottomUpMailStorageTraversalResult } from 'freedom-email-sync';
+import { addMail, traverseTimeOrganizedMailStorageFromTheBottomUp } from 'freedom-email-sync';
+import { clearDocumentCache } from 'freedom-syncable-store';
+import { expectDeepStrictEqual, expectOk } from 'freedom-testing-tools';
+
+import { createEmailStoreTestStack } from '../__test_dependency__/createEmailStoreTestStack.ts';
+import { createInitialSyncableStoreStructureForUser } from '../utils/createInitialSyncableStoreStructureForUser.ts';
+import { getUserMailPaths } from '../utils/getUserMailPaths.ts';
+
+describe('traverseTimeOrganizedMailStorageFromTheBottomUp', () => {
+  afterEach(clearDocumentCache);
+
+  it('should work with no emails', async () => {
+    // Arrange
+    const { trace, access } = await createEmailStoreTestStack();
+
+    const userFs = access.userFs;
+    const paths = await getUserMailPaths(userFs);
+
+    expectOk(await createInitialSyncableStoreStructureForUser(trace, access));
+
+    // Act
+    const callOrder: string[] = [];
+    expectOk(
+      await traverseTimeOrganizedMailStorageFromTheBottomUp(
+        trace,
+        access,
+        { timeOrganizedMailStorage: paths.storage },
+        async (_trace, cursor): PR<BottomUpMailStorageTraversalResult> => {
+          callOrder.push(
+            `${cursor.type}:${cursor.value.year}${cursor.value.month !== undefined ? `/${cursor.value.month}` : ''}${cursor.value.day !== undefined ? `/${cursor.value.day}` : ''}${cursor.value.hour !== undefined ? `/${cursor.value.hour}` : ''}`
+          );
+          return makeSuccess('inspect' as const);
+        }
+      )
+    );
+
+    // Assert
+    expectDeepStrictEqual(callOrder, []);
+  });
+
+  it('should work with single email', async () => {
+    // Arrange
+    const { trace, access } = await createEmailStoreTestStack();
+
+    const userFs = access.userFs;
+    const paths = await getUserMailPaths(userFs);
+
+    expectOk(await createInitialSyncableStoreStructureForUser(trace, access));
+
+    expectOk(
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T03:00:00.000Z').getTime()
+      })
+    );
+
+    // Act
+    const callOrder: string[] = [];
+    expectOk(
+      await traverseTimeOrganizedMailStorageFromTheBottomUp(
+        trace,
+        access,
+        { timeOrganizedMailStorage: paths.storage },
+        async (_trace, cursor): PR<BottomUpMailStorageTraversalResult> => {
+          callOrder.push(
+            `${cursor.type}:${cursor.value.year}${cursor.value.month !== undefined ? `/${cursor.value.month}` : ''}${cursor.value.day !== undefined ? `/${cursor.value.day}` : ''}${cursor.value.hour !== undefined ? `/${cursor.value.hour}` : ''}`
+          );
+          return makeSuccess('inspect' as const);
+        }
+      )
+    );
+
+    // Assert
+    expectDeepStrictEqual(callOrder, [`year:2025`, `month:2025/1`, `day:2025/1/2`, `hour:2025/1/2/3`]);
+  });
+
+  it('should work with multiple emails', async () => {
+    // Arrange
+    const { trace, access } = await createEmailStoreTestStack();
+
+    const userFs = access.userFs;
+    const paths = await getUserMailPaths(userFs);
+
+    expectOk(await createInitialSyncableStoreStructureForUser(trace, access));
+
+    expectOk(
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T03:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month, day, hour
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T03:01:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month, day
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T02:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-01T00:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-02-01T00:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Different year
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2024-01-01T00:00:00.000Z').getTime()
+      })
+    );
+
+    // Act
+    const callOrder: string[] = [];
+    expectOk(
+      await traverseTimeOrganizedMailStorageFromTheBottomUp(
+        trace,
+        access,
+        { timeOrganizedMailStorage: paths.storage },
+        async (_trace, cursor): PR<BottomUpMailStorageTraversalResult> => {
+          callOrder.push(
+            `${cursor.type}:${cursor.value.year}${cursor.value.month !== undefined ? `/${cursor.value.month}` : ''}${cursor.value.day !== undefined ? `/${cursor.value.day}` : ''}${cursor.value.hour !== undefined ? `/${cursor.value.hour}` : ''}`
+          );
+          return makeSuccess('inspect' as const);
+        }
+      )
+    );
+
+    // Assert
+    expectDeepStrictEqual(callOrder, [
+      `year:2025`,
+      `month:2025/2`,
+      `day:2025/2/1`,
+      `hour:2025/2/1/0`,
+      `month:2025/1`,
+      `day:2025/1/2`,
+      `hour:2025/1/2/3`,
+      `hour:2025/1/2/2`,
+      `day:2025/1/1`,
+      `hour:2025/1/1/0`,
+      `year:2024`,
+      `month:2024/1`,
+      `day:2024/1/1`,
+      `hour:2024/1/1/0`
+    ]);
+  });
+
+  it('stopping and resuming using offset should work with multiple emails', async () => {
+    // Arrange
+    const { trace, access } = await createEmailStoreTestStack();
+
+    const userFs = access.userFs;
+    const paths = await getUserMailPaths(userFs);
+
+    expectOk(await createInitialSyncableStoreStructureForUser(trace, access));
+
+    expectOk(
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T03:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month, day, hour
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T03:01:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month, day
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-02T02:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year, month
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-01-01T00:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Same year
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2025-02-01T00:00:00.000Z').getTime()
+      })
+    );
+    expectOk(
+      // Different year
+      await addMail(trace, access, {
+        from: 'test@freedomtechhq.com',
+        to: ['test@freedomtechhq.com'],
+        subject: 'Welcome to Freedom!',
+        body: 'This is a test email',
+        timeMSec: new Date('2024-01-01T00:00:00.000Z').getTime()
+      })
+    );
+
+    // Act
+    const callOrder1: string[] = [];
+    expectOk(
+      await traverseTimeOrganizedMailStorageFromTheBottomUp(
+        trace,
+        access,
+        { timeOrganizedMailStorage: paths.storage },
+        async (_trace, cursor): PR<BottomUpMailStorageTraversalResult> => {
+          if (
+            cursor.type === 'hour' &&
+            cursor.value.year === 2025 &&
+            cursor.value.month === 1 &&
+            cursor.value.day === 2 &&
+            cursor.value.hour === 3
+          ) {
+            return makeSuccess('stop' as const);
+          }
+
+          callOrder1.push(
+            `${cursor.type}:${cursor.value.year}${cursor.value.month !== undefined ? `/${cursor.value.month}` : ''}${cursor.value.day !== undefined ? `/${cursor.value.day}` : ''}${cursor.value.hour !== undefined ? `/${cursor.value.hour}` : ''}`
+          );
+          return makeSuccess('inspect' as const);
+        }
+      )
+    );
+
+    const callOrder2: string[] = [];
+    expectOk(
+      await traverseTimeOrganizedMailStorageFromTheBottomUp(
+        trace,
+        access,
+        { timeOrganizedMailStorage: paths.storage, offset: { year: 2025, month: 1, day: 2, hour: 3 } },
+        async (_trace, cursor): PR<BottomUpMailStorageTraversalResult> => {
+          callOrder2.push(
+            `${cursor.type}:${cursor.value.year}${cursor.value.month !== undefined ? `/${cursor.value.month}` : ''}${cursor.value.day !== undefined ? `/${cursor.value.day}` : ''}${cursor.value.hour !== undefined ? `/${cursor.value.hour}` : ''}`
+          );
+          return makeSuccess('inspect' as const);
+        }
+      )
+    );
+
+    // Assert
+    expectDeepStrictEqual(callOrder1, [`year:2025`, `month:2025/2`, `day:2025/2/1`, `hour:2025/2/1/0`, `month:2025/1`, `day:2025/1/2`]);
+    expectDeepStrictEqual(callOrder2, [
+      `hour:2025/1/2/3`,
+      `hour:2025/1/2/2`,
+      `day:2025/1/1`,
+      `hour:2025/1/1/0`,
+      `year:2024`,
+      `month:2024/1`,
+      `day:2024/1/1`,
+      `hour:2024/1/1/0`
+    ]);
+  });
+});

--- a/code/freedom-email.code-workspace
+++ b/code/freedom-email.code-workspace
@@ -187,5 +187,26 @@
             "path": "server-packages/freedom-sqlite-object-store"
         }
     ],
-    "settings": {}
+    "settings": {},
+    "tasks": {
+        "version": "2.0.0",
+        "tasks": [
+            {
+                "label": "prep:dev",
+                "command": "yarn prep:dev",
+                "type": "shell",
+                "args": [],
+                "options": {
+                    "cwd": "${workspaceFolder}/../.."
+                },
+                "problemMatcher": [
+                    "$tsc"
+                ],
+                "presentation": {
+                    "reveal": "always"
+                },
+                "group": "build"
+            }
+        ]
+    }
 }

--- a/code/web-worker-packages/freedom-email-tasks-web-worker/src/tasks/mail/getMailThreadsForCollection.ts
+++ b/code/web-worker-packages/freedom-email-tasks-web-worker/src/tasks/mail/getMailThreadsForCollection.ts
@@ -16,8 +16,6 @@ import { getOrCreateEmailAccessForUser } from '../../internal/tasks/user/getOrCr
 import type { GetMailThreadsForCollection_MailAddedPacket } from '../../types/mail/getMailThreadsForCollection/GetMailThreadsForCollection_MailAddedPacket.ts';
 import type { GetMailThreadsForCollectionPacket } from '../../types/mail/getMailThreadsForCollection/GetMailThreadsForCollectionPacket.ts';
 
-// const globalCache: Record<MailCollectionId, MailThread[]> = {};
-
 export const getMailThreadsForCollection = makeAsyncResultFunc(
   [import.meta.filename],
   async (


### PR DESCRIPTION
- addMail now uses the timeMSec on the StoredMail to generate the MailId
- Fixed an issue on listTimeOrganizedMailIds where numbers werent parsed properly
- Added makeBottomUpTimeOrganizedMailStorageTraverser and traverseTimeOrganizedMailStorageFromTheBottomUp to simplify mail storage traversal