### PR TITLE
Added freedom-json-file-object-store

### DIFF
--- a/code/cross-platform-packages/freedom-object-store-types/src/types/StorableObject.ts
+++ b/code/cross-platform-packages/freedom-object-store-types/src/types/StorableObject.ts
@@ -1,3 +1,12 @@
+import { nonNegativeIntegerSchema } from 'freedom-basic-data';
+import type { Schema } from 'yaschema';
+import { schema } from 'yaschema';
+
+export const makeStorableObjectSchema = <T>(storedValueSchema: Schema<T>) =>
+  schema.object<StorableObject<T>, 'no-infer'>({
+    storedValue: storedValueSchema,
+    updateCount: nonNegativeIntegerSchema
+  });
 export interface StorableObject<T> {
   storedValue: T;
   updateCount: number;

--- a/code/cross-platform-packages/freedom-serialization/package.json
+++ b/code/cross-platform-packages/freedom-serialization/package.json
@@ -4,9 +4,11 @@
     "freedom-basic-data": "0.0.0",
     "freedom-common-errors": "0.0.0",
     "freedom-contexts": "0.0.0",
+    "lodash-es": "4.17.21",
     "yaschema": "4.4.5"
   },
   "devDependencies": {
+    "@types/lodash-es": "4.17.12",
     "freedom-build-tools": "0.0.0",
     "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"

--- a/code/cross-platform-packages/freedom-serialization/src/utils/__tests__/serialization-deserialization.test.ts
+++ b/code/cross-platform-packages/freedom-serialization/src/utils/__tests__/serialization-deserialization.test.ts
@@ -9,7 +9,7 @@ import { serialize } from '../serialize.ts';
 
 const theSchema = schema.object({ one: schema.number() });
 
-describe('serialization', () => {
+describe('serialization and deserialization', () => {
   it('should work', async (t) => {
     const trace = makeTrace('test');
 

--- a/code/cross-platform-packages/freedom-serialization/src/utils/__tests__/stringify-parse.test.ts
+++ b/code/cross-platform-packages/freedom-serialization/src/utils/__tests__/stringify-parse.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+
+import { makeTrace } from 'freedom-contexts';
+import { expectOk } from 'freedom-testing-tools';
+import { schema } from 'yaschema';
+
+import { parse } from '../parse.ts';
+import { stringify } from '../stringify.ts';
+
+const theSchema = schema.object({ one: schema.number() });
+
+describe('stringify and parse', () => {
+  it('should work', async (t) => {
+    const trace = makeTrace('test');
+
+    const jsonString = await stringify(trace, { one: 1 }, theSchema);
+    expectOk(jsonString);
+    t.assert.deepEqual(jsonString.value, '{"one":1}');
+
+    const parsed = await parse(trace, jsonString.value, theSchema);
+    expectOk(parsed);
+    t.assert.deepEqual(parsed.value, { one: 1 });
+  });
+});

--- a/code/cross-platform-packages/freedom-serialization/src/utils/exports.ts
+++ b/code/cross-platform-packages/freedom-serialization/src/utils/exports.ts
@@ -1,2 +1,4 @@
 export * from './deserialize.ts';
+export * from './parse.ts';
 export * from './serialize.ts';
+export * from './stringify.ts';

--- a/code/cross-platform-packages/freedom-serialization/src/utils/parse.ts
+++ b/code/cross-platform-packages/freedom-serialization/src/utils/parse.ts
@@ -1,0 +1,23 @@
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import { get } from 'lodash-es';
+import type { Schema } from 'yaschema';
+
+export const parse = makeAsyncResultFunc(
+  [import.meta.filename],
+  async <T>(trace: Trace, jsonString: string, valueSchema: Schema<T>): PR<T> => {
+    try {
+      const parsed = await valueSchema.parseAsync(jsonString, { validation: 'hard' });
+      return makeSuccess(parsed);
+    } catch (e) {
+      const error = get(e, 'error');
+      if (typeof error === 'string') {
+        return makeFailure(new InternalSchemaValidationError(trace, { message: error }));
+      } else {
+        return makeFailure(new GeneralError(trace, e));
+      }
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-serialization/src/utils/stringify.ts
+++ b/code/cross-platform-packages/freedom-serialization/src/utils/stringify.ts
@@ -1,0 +1,23 @@
+import type { PR } from 'freedom-async';
+import { GeneralError, makeAsyncResultFunc, makeFailure, makeSuccess } from 'freedom-async';
+import { InternalSchemaValidationError } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import { get } from 'lodash-es';
+import type { Schema, StringifyOptions, ValidationOptions } from 'yaschema';
+
+export const stringify = makeAsyncResultFunc(
+  [import.meta.filename],
+  async <T>(trace: Trace, value: T, valueSchema: Schema<T>, options?: Omit<StringifyOptions, keyof ValidationOptions>): PR<string> => {
+    try {
+      const jsonString = await valueSchema.stringifyAsync(value, { ...options, validation: 'hard' });
+      return makeSuccess(jsonString);
+    } catch (e) {
+      const error = get(e, 'error');
+      if (typeof error === 'string') {
+        return makeFailure(new InternalSchemaValidationError(trace, { message: error }));
+      } else {
+        return makeFailure(new GeneralError(trace, e));
+      }
+    }
+  }
+);

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
@@ -210,7 +210,7 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
 
                 if (event.path.startsWith(currentSnapshotDeltasBundlePath)) {
                   pendingDeltaPaths.push(event.path);
-                  pendingDeltasTaskQueue.add('apply-pending-deltas', applyPendingDeltasNow);
+                  pendingDeltasTaskQueue.add({ key: 'apply-pending-deltas', version: makeUuid() }, applyPendingDeltasNow);
                 }
               }
             })

--- a/code/freedom-email.code-workspace
+++ b/code/freedom-email.code-workspace
@@ -160,6 +160,9 @@
             "path": "server-packages/freedom-file-system-syncable-store-backing"
         },
         {
+            "path": "server-packages/freedom-json-file-object-store"
+        },
+        {
             "path": "server-packages/freedom-server-api-handling"
         },
         {
@@ -170,6 +173,9 @@
         },
         {
             "path": "server-packages/freedom-server-trace-auth-token"
+        },
+        {
+            "path": "server-packages/freedom-sqlite-object-store"
         },
         {
             "path": "web-packages/freedom-indexeddb-object-store"
@@ -185,9 +191,6 @@
         },
         {
             "path": "web-worker-packages/freedom-email-tasks-web-worker"
-        },
-        {
-            "path": "server-packages/freedom-sqlite-object-store"
         }
     ],
     "settings": {},

--- a/code/server-packages/freedom-json-file-object-store/README.md
+++ b/code/server-packages/freedom-json-file-object-store/README.md
@@ -1,0 +1,19 @@
+# freedom-sqlite-object-store
+
+## Summary
+
+Provides types and utilities for working with SQLite-based object stores in server-side applications.
+
+## Overview
+
+This package exports types and helpers for defining, accessing, and managing object stores backed by SQLite databases.
+
+### Main Exports
+
+- Types for SQLite object store schemas and operations
+
+## Usage
+
+Use these types and utilities to implement object store logic using SQLite in your server-side code.
+
+---

--- a/code/server-packages/freedom-json-file-object-store/package.json
+++ b/code/server-packages/freedom-json-file-object-store/package.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
     "freedom-async": "0.0.0",
-    "freedom-basic-data": "0.0.0",
     "freedom-cast": "0.0.0",
     "freedom-common-errors": "0.0.0",
     "freedom-contexts": "0.0.0",
-    "freedom-indexing-types": "0.0.0",
+    "freedom-object-store-types": "0.0.0",
     "freedom-paginated-data": "0.0.0",
+    "freedom-serialization": "0.0.0",
+    "freedom-task-queue": "0.0.0",
     "lodash-es": "4.17.21",
     "yaschema": "4.4.5"
   },
@@ -18,12 +19,11 @@
   },
   "type": "module",
   "main": "lib/exports.mjs",
-  "name": "freedom-object-store-types",
+  "name": "freedom-json-file-object-store",
   "nx": {
     "tags": [
       "type:lib",
-      "platform:server",
-      "platform:web"
+      "platform:server"
     ]
   },
   "private": true,
@@ -32,7 +32,7 @@
     "build:dev": "FREEDOM_BUILD_MODE=DEV yarn build",
     "build:tests": "tsc",
     "clean": "rimraf ./coverage ./lib",
-    "depcheck": "depcheck --ignores=freedom-build-tools || (code ./package.json && exit 1)",
+    "depcheck": "depcheck --ignores=freedom-build-tools,@types/multer || (code ./package.json && exit 1)",
     "lint": "eslint 'src/**/*.ts?(x)' --max-warnings 0",
     "test": "yarn test:unit-tests",
     "test:debug": "FREEDOM_VERBOSE_LOGGING=${FREEDOM_VERBOSE_LOGGING:-true} FREEDOM_LOGGING_MODE_DEFAULT=${FREEDOM_LOGGING_MODE_DEFAULT:-flat} FREEDOM_MAX_CONCURRENCY_DEFAULT=${FREEDOM_MAX_CONCURRENCY_DEFAULT:-1} yarn test",

--- a/code/server-packages/freedom-json-file-object-store/src/exports.ts
+++ b/code/server-packages/freedom-json-file-object-store/src/exports.ts
@@ -1,0 +1,1 @@
+export * from './types/exports.ts';

--- a/code/server-packages/freedom-json-file-object-store/src/types/JsonFileObjectStore.ts
+++ b/code/server-packages/freedom-json-file-object-store/src/types/JsonFileObjectStore.ts
@@ -1,0 +1,241 @@
+import fs from 'node:fs/promises';
+
+import type { PR } from 'freedom-async';
+import { allResultsMapped, makeAsyncResultFunc, makeSuccess, uncheckedResult } from 'freedom-async';
+import { objectEntries } from 'freedom-cast';
+import { generalizeFailureResult } from 'freedom-common-errors';
+import type { Trace } from 'freedom-contexts';
+import { makeTrace, makeUuid } from 'freedom-contexts';
+import {
+  InMemoryObjectStore,
+  type MutableObjectAccessor,
+  type MutableObjectStore,
+  type ObjectAccessor,
+  type ObjectStoreManagement,
+  type StorableObject
+} from 'freedom-object-store-types';
+import type { PageToken, Paginated } from 'freedom-paginated-data';
+import { parse, stringify } from 'freedom-serialization';
+import { TaskQueue } from 'freedom-task-queue';
+import { once } from 'lodash-es';
+import { type Schema, schema } from 'yaschema';
+
+export type JsonFileObjectStoreConstructorArgs<KeyT extends string, T> = {
+  path: string;
+  schema: Schema<T>;
+  _keyType?: KeyT;
+};
+
+export class JsonFileObjectStore<KeyT extends string, T> implements MutableObjectStore<KeyT, T>, ObjectStoreManagement<KeyT, T> {
+  public readonly uid = makeUuid();
+
+  public readonly inMemoryStore_: InMemoryObjectStore<KeyT, T>;
+  public get keys() {
+    return this.inMemoryStore_.keys;
+  }
+
+  private readonly path_: string;
+  private readonly persistenceTaskQueue_ = new TaskQueue(makeTrace(import.meta.filename));
+
+  private readonly recordSchema_: Schema<Partial<Record<KeyT, T>>>;
+
+  constructor({ path, schema: valueSchema }: JsonFileObjectStoreConstructorArgs<KeyT, T>) {
+    this.recordSchema_ = schema.record(schema.string(), valueSchema);
+    this.path_ = path;
+
+    this.inMemoryStore_ = new InMemoryObjectStore<KeyT, T>({ schema: valueSchema });
+    this.persistenceTaskQueue_.start();
+  }
+
+  /** Optionally call to forcibly load.  Otherwise, this will happen lazily */
+  public readonly initialize = makeAsyncResultFunc(
+    [import.meta.filename, 'initialize'],
+    async (trace): PR<undefined> => await this.loadIfNeeded_(trace)
+  );
+
+  /** Wait for any outstanding persistence operations to complete */
+  public readonly waitForPersistence = makeAsyncResultFunc([import.meta.filename, 'waitForPersistence'], async (_trace): PR<undefined> => {
+    await this.persistenceTaskQueue_.wait();
+    return makeSuccess(undefined);
+  });
+
+  // MutableObjectStore Methods
+
+  public mutableObject(key: KeyT): MutableObjectAccessor<T> {
+    const readonlyValues = this.object(key);
+
+    const create = makeAsyncResultFunc(
+      [import.meta.filename, 'mutableObject', 'create'],
+      async (trace: Trace, initialValue: T): PR<T, 'conflict'> => {
+        await uncheckedResult(this.loadIfNeeded_(trace));
+
+        const created = await this.inMemoryStore_.mutableObject(key).create(trace, initialValue);
+        if (!created.ok) {
+          return created;
+        }
+
+        this.persistenceTaskQueue_.add({ key: 'persist', version: makeUuid() }, this.persistToFile_);
+
+        return makeSuccess(created.value);
+      }
+    );
+
+    const getMutable = makeAsyncResultFunc(
+      [import.meta.filename, 'mutableObject', 'getMutable'],
+      async (trace): PR<StorableObject<T>, 'not-found'> => {
+        await uncheckedResult(this.loadIfNeeded_(trace));
+
+        return await this.inMemoryStore_.mutableObject(key).getMutable(trace);
+      }
+    );
+
+    return {
+      ...readonlyValues,
+
+      create,
+
+      delete: makeAsyncResultFunc([import.meta.filename, 'mutableObject', 'delete'], async (trace): PR<undefined, 'not-found'> => {
+        await uncheckedResult(this.loadIfNeeded_(trace));
+
+        const deleted = await this.inMemoryStore_.mutableObject(key).delete(trace);
+        if (!deleted.ok) {
+          return deleted;
+        }
+
+        this.persistenceTaskQueue_.add({ key: 'persist', version: makeUuid() }, this.persistToFile_);
+
+        return makeSuccess(deleted.value);
+      }),
+
+      getMutable,
+
+      update: makeAsyncResultFunc(
+        [import.meta.filename, 'mutableObject', 'update'],
+        async (trace, newValue: StorableObject<T>): PR<undefined, 'not-found' | 'out-of-date'> => {
+          await uncheckedResult(this.loadIfNeeded_(trace));
+
+          const updated = await this.inMemoryStore_.mutableObject(key).update(trace, newValue);
+          if (!updated.ok) {
+            return updated;
+          }
+
+          this.persistenceTaskQueue_.add({ key: 'persist', version: makeUuid() }, this.persistToFile_);
+
+          return makeSuccess(updated.value);
+        }
+      )
+    };
+  }
+
+  // ObjectStore Methods
+
+  public object(key: KeyT): ObjectAccessor<T> {
+    return {
+      exists: makeAsyncResultFunc([import.meta.filename, 'object', 'exists'], async (trace): PR<boolean> => {
+        await uncheckedResult(this.loadIfNeeded_(trace));
+
+        return await this.inMemoryStore_.object(key).exists(trace);
+      }),
+
+      get: makeAsyncResultFunc([import.meta.filename, 'object', 'get'], async (trace): PR<T, 'not-found'> => {
+        await uncheckedResult(this.loadIfNeeded_(trace));
+
+        return await this.inMemoryStore_.object(key).get(trace);
+      })
+    };
+  }
+
+  public async getMultiple(trace: Trace, keys: KeyT[]): PR<{ found: Partial<Record<KeyT, T>>; notFound: KeyT[] }> {
+    await uncheckedResult(this.loadIfNeeded_(trace));
+
+    return await this.inMemoryStore_.getMultiple(trace, keys);
+  }
+
+  // ObjectStoreManagementAccessor Methods
+
+  public readonly getDeletedKeys = makeAsyncResultFunc(
+    [import.meta.filename, 'getDeletedKeys'],
+    async (trace: Trace, startFromPageToken?: PageToken): PR<Paginated<KeyT>> => {
+      await uncheckedResult(this.loadIfNeeded_(trace));
+
+      return await this.inMemoryStore_.getDeletedKeys(trace, startFromPageToken);
+    }
+  );
+
+  public readonly sweep = makeAsyncResultFunc([import.meta.filename, 'sweep'], async (trace: Trace): PR<KeyT[]> => {
+    await uncheckedResult(this.loadIfNeeded_(trace));
+
+    return await this.inMemoryStore_.sweep(trace);
+  });
+
+  // Private Methods
+
+  private readonly loadIfNeeded_ = makeAsyncResultFunc(
+    [import.meta.filename, 'loadIfNeeded_'],
+    once(async (trace): PR<undefined> => {
+      let jsonString = '{}';
+      try {
+        jsonString = await fs.readFile(this.path_, 'utf-8');
+      } catch (_e) {
+        // Ignoring file read errors, since this probably means the file doesn't exist
+      }
+
+      const parsed = await parse(trace, jsonString, this.recordSchema_);
+      /* node:coverage disable */
+      if (!parsed.ok) {
+        return parsed;
+      }
+      /* node:coverage enable */
+
+      const initialized = await allResultsMapped(trace, objectEntries(parsed.value), {}, async (trace, [key, value]) => {
+        if (value === undefined) {
+          return makeSuccess(undefined);
+        }
+
+        const created = await this.inMemoryStore_.mutableObject(key).create(trace, value);
+        /* node:coverage disable */
+        if (!created.ok) {
+          // Conflicts should never happen here since we're initializing a new object store
+          return generalizeFailureResult(trace, created, 'conflict');
+        }
+        /* node:coverage enable */
+
+        return makeSuccess(undefined);
+      });
+      /* node:coverage disable */
+      if (!initialized.ok) {
+        return initialized;
+      }
+      /* node:coverage enable */
+
+      return makeSuccess(undefined);
+    })
+  );
+
+  private readonly persistToFile_ = makeAsyncResultFunc([import.meta.filename, 'persistToFile_'], async (trace): PR<undefined> => {
+    const keys = await this.inMemoryStore_.keys.asc().keys(trace);
+    /* node:coverage disable */
+    if (!keys.ok) {
+      return keys;
+    }
+    /* node:coverage enable */
+
+    const got = await this.inMemoryStore_.getMultiple(trace, keys.value);
+    /* node:coverage disable */
+    if (!got.ok) {
+      return got;
+    }
+    /* node:coverage enable */
+
+    const jsonString = await stringify(trace, got.value.found, this.recordSchema_, { space: 2 });
+    /* node:coverage disable */
+    if (!jsonString.ok) {
+      return jsonString;
+    }
+    /* node:coverage enable */
+
+    await fs.writeFile(this.path_, jsonString.value, 'utf-8');
+
+    return makeSuccess(undefined);
+  });
+}

--- a/code/server-packages/freedom-json-file-object-store/src/types/__tests__/JsonFileObjectStore.test.ts
+++ b/code/server-packages/freedom-json-file-object-store/src/types/__tests__/JsonFileObjectStore.test.ts
@@ -1,0 +1,128 @@
+import os from 'node:os';
+import path from 'node:path';
+import type { TestContext } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import type { Trace } from 'freedom-contexts';
+import { makeTrace, makeUuid } from 'freedom-contexts';
+import { createOrGetObject } from 'freedom-object-store-types';
+import { expectDeepStrictEqual, expectErrorCode, expectOk, expectStrictEqual } from 'freedom-testing-tools';
+import { schema } from 'yaschema';
+
+import { JsonFileObjectStore } from '../JsonFileObjectStore.ts';
+
+const valueSchema = schema.number();
+
+describe('JsonFileObjectStore', () => {
+  let trace: Trace;
+  let jsonFilePath: string;
+  let objectStore: JsonFileObjectStore<string, number>;
+  beforeEach(async () => {
+    trace = makeTrace('test');
+
+    jsonFilePath = path.join(os.tmpdir(), `testing-${makeUuid()}.json`);
+    console.log('jsonFilePath', jsonFilePath);
+    objectStore = new JsonFileObjectStore({ path: jsonFilePath, schema: valueSchema });
+    expectOk(await objectStore.initialize(trace));
+  });
+
+  afterEach(async () => {
+    expectOk(await objectStore.waitForPersistence(trace));
+  });
+
+  it('A conflict failure should be returned if trying to create an entry with a key that already exists', async (_t: TestContext) => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    expectErrorCode(await objectStore.mutableObject('a').create(trace, 6.28), 'conflict');
+  });
+
+  it('The stored value should be returned for createOrGet for entries with keys that already exist', async (t: TestContext) => {
+    expectOk(await createOrGetObject(trace, objectStore.mutableObject('a'), 3.14));
+
+    const found = await createOrGetObject(trace, objectStore.mutableObject('a'), 6.28);
+    expectOk(found);
+    t.assert.strictEqual(found.value, 3.14);
+  });
+
+  it('Deleting existing entries should work', async (t: TestContext) => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    expectOk(await objectStore.mutableObject('a').delete(trace));
+
+    const deletedKeys1 = await objectStore.getDeletedKeys(trace);
+    expectOk(deletedKeys1);
+    t.assert.deepStrictEqual(deletedKeys1.value.items, ['a']);
+
+    await objectStore.sweep(trace);
+
+    const deletedKeys2 = await objectStore.getDeletedKeys(trace);
+    expectOk(deletedKeys2);
+    t.assert.strictEqual(deletedKeys2.value.items.length, 0);
+  });
+
+  it('Exists should work', async (_t: TestContext) => {
+    const aExists1 = await objectStore.object('a').exists(trace);
+    expectOk(aExists1);
+    expectStrictEqual(aExists1.value, false);
+
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    const aExists2 = await objectStore.object('a').exists(trace);
+    expectOk(aExists2);
+    expectStrictEqual(aExists2.value, true);
+  });
+
+  it("A not-found failure should be returned if trying to delete an entry that doesn't exist", async (_t: TestContext) => {
+    expectErrorCode(await objectStore.mutableObject('a').delete(trace), 'not-found');
+  });
+
+  it('Updating existing entries should work', async (t: TestContext) => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    const value1 = await objectStore.object('a').get(trace);
+    expectOk(value1);
+    t.assert.strictEqual(value1.value, 3.14);
+
+    expectOk(await objectStore.mutableObject('a').update(trace, { storedValue: 6.28, updateCount: 0 }));
+
+    const value2 = await objectStore.object('a').get(trace);
+    expectOk(value2);
+    t.assert.strictEqual(value2.value, 6.28);
+  });
+
+  it('Updating existing entries should work with getMutable', async (t: TestContext) => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    const value1 = await objectStore.mutableObject('a').getMutable(trace);
+    expectOk(value1);
+    t.assert.strictEqual(value1.value.storedValue, 3.14);
+    t.assert.strictEqual(value1.value.updateCount, 0);
+
+    expectOk(await objectStore.mutableObject('a').update(trace, { storedValue: 6.28, updateCount: value1.value.updateCount }));
+
+    const value2 = await objectStore.object('a').get(trace);
+    expectOk(value2);
+    t.assert.strictEqual(value2.value, 6.28);
+  });
+
+  it('An out-of-date failure should be returned if trying to update an existing entry with the wrong updateCount', async (t: TestContext) => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+
+    const value1 = await objectStore.object('a').get(trace);
+    expectOk(value1);
+    t.assert.strictEqual(value1.value, 3.14);
+
+    expectErrorCode(await objectStore.mutableObject('a').update(trace, { storedValue: 6.28, updateCount: 1 }), 'out-of-date');
+  });
+
+  it('get multiple should work', async () => {
+    expectOk(await objectStore.mutableObject('a').create(trace, 3.14));
+    expectOk(await objectStore.mutableObject('b').create(trace, 6.28));
+    expectOk(await objectStore.mutableObject('c').create(trace, 9.42));
+
+    const got = await objectStore.getMultiple(trace, ['a', 'b', 'c', 'd']);
+    expectOk(got);
+    expectDeepStrictEqual(got.value.found, { a: 3.14, b: 6.28, c: 9.42 });
+    expectDeepStrictEqual(got.value.notFound, ['d']);
+  });
+});

--- a/code/server-packages/freedom-json-file-object-store/src/types/exports.ts
+++ b/code/server-packages/freedom-json-file-object-store/src/types/exports.ts
@@ -1,0 +1,1 @@
+export * from './JsonFileObjectStore.ts';

--- a/code/server-packages/freedom-json-file-object-store/tsconfig.base.json
+++ b/code/server-packages/freedom-json-file-object-store/tsconfig.base.json
@@ -1,0 +1,78 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2023",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "ES2020",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "ES2023",
+      "DOM"
+    ],        
+    /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationDir" : "./lib",
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./lib/",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src/",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "noEmit": true,
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "noErrorTruncation": true,
+
+    "resolveJsonModule": true
+  },
+  "compileOnSave": true
+}

--- a/code/server-packages/freedom-json-file-object-store/tsconfig.json
+++ b/code/server-packages/freedom-json-file-object-store/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [ "src", "**/__tests__", "**/__test_dependency__" ],
+  "exclude": [ "lib" ]
+}

--- a/code/server-packages/freedom-json-file-object-store/tsconfig.mjs.json
+++ b/code/server-packages/freedom-json-file-object-store/tsconfig.mjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "noEmit": false
+  },
+  "include": [ "src" ],
+  "exclude": [ "**/__tests__", "**/__test_dependency__", "lib" ]
+}


### PR DESCRIPTION
- A new ObjectStore implementation for persisting to JSON files, for testing purposes mostly
- This reads from a JSON file (which may or may not initially exist) and eventually persists changes back into that JSON file

Other semi-related changes:
- Added parse and stringify methods to freedom-serialization
- Added makeStorableObjectSchema helper (to go along with StorableObject)
- Fixed an issue with TaskQueue and dealing with multiple tasks for the same key when one is in flight