### PR TITLE
Explain devOnEnvChange('FREEDOM_VERBOSE_LOGGING')

### DIFF
--- a/code/cross-platform-packages/freedom-async/src/config/logging.ts
+++ b/code/cross-platform-packages/freedom-async/src/config/logging.ts
@@ -21,10 +21,11 @@ export const resetLogger = () => {
 };
 
 DEV: {
-  let lastLogger: Logger = globalLogger;
+  let loggerByEnvConfig: Logger = globalLogger;
 
   devOnEnvChange('FREEDOM_VERBOSE_LOGGING', process.env.FREEDOM_VERBOSE_LOGGING, async (envValue) => {
-    if (globalLogger === lastLogger) {
+    // Only override own logger. Do not override anything set by an explicit call of setLogger()
+    if (globalLogger !== loggerByEnvConfig) {
       return;
     }
 
@@ -35,6 +36,6 @@ DEV: {
       resetLogger();
     }
 
-    lastLogger = globalLogger;
+    loggerByEnvConfig = globalLogger;
   });
 }

--- a/code/cross-platform-packages/freedom-async/src/config/logging.ts
+++ b/code/cross-platform-packages/freedom-async/src/config/logging.ts
@@ -24,7 +24,7 @@ DEV: {
   let lastLogger: Logger = globalLogger;
 
   devOnEnvChange('FREEDOM_VERBOSE_LOGGING', process.env.FREEDOM_VERBOSE_LOGGING, async (envValue) => {
-    if (globalLogger !== lastLogger) {
+    if (globalLogger === lastLogger) {
       return;
     }
 


### PR DESCRIPTION
@brianwestphal Please check.

I still don't understand how this part works (still forgetting that `DEV:` requires its own build env var). But this fix seems obvious.