### PR TITLE
in email column list always show date / time and truncate From instead

### DIFF
--- a/code/apps/freedom-email-app/src/modules/mail-collection/components/MailThreadListItem.tsx
+++ b/code/apps/freedom-email-app/src/modules/mail-collection/components/MailThreadListItem.tsx
@@ -69,14 +69,14 @@ export const MailThreadListItem = <TagT,>({ thread, tag, onClick }: MailThreadLi
           </ListItemAvatar>
           <Stack alignItems="stretch" sx={overflowHiddenStyle}>
             <Stack direction="row" justifyContent="space-between" gap={1} sx={overflowHiddenStyle}>
-              <span>
+              <Stack sx={{ overflow: 'hidden', flexGrow: 1, flexShrink: 1 }}>
                 {fromStrings.map((from, index) => (
                   <Typography key={index} fontWeight="bold" sx={ellipsizeStyle}>
                     {`${index > 0 ? ', ' : ''}${from}`}
                   </Typography>
                 ))}
-              </span>
-              <Typography variant="body2" color="textSecondary" sx={noWrapStyle}>
+              </Stack>
+              <Typography variant="body2" color="textSecondary" sx={{ ...noWrapStyle, flexShrink: 0, minWidth: '5rem' }}>
                 {formatTimeIfSameDateOrFormatDate(thread.timeMSec)}
               </Typography>
             </Stack>


### PR DESCRIPTION
fix #73 

> in freedom-email-app fix the bug where in the list of emails the date / time isn't shown if the from name is too long. the from name should be clipped so the date / time always shows

⏺ Task(Find files in the freedom-email-app project that display the list of emails with date/time and from name. This will likely be in a component that renders the email list items. Look for files with names like …
      MailThreadListItem.tsx, MailCollectionListItem.tsx, or similar in the mail-collection or mail-collections-list modules.)
  ⎿  Done (5 tool uses · 20.5k tokens · 27.6s)

⏺ Read(code/apps/freedom-email-app/src/modules/mail-collection/components/MailThreadListItem.tsx)…
  ⎿  Read 108 lines (ctrl+r to expand)

⏺ I found the issue. In the MailThreadListItem.tsx file, the from name and the date/time are both in the same row, but when the from name is too long, it can push the date/time off the display.

  The problem is in the layout structure around lines 71-82. The fromStrings are wrapped in a <span> element without proper constraints, and although the individual Typography components for the from names have ellipsis styling,
   the container isn't constrained properly.

  Let's fix this by:

  1. Adding a width constraint to the container that holds the sender names
  2. Ensuring the date/time has a minimum width and doesn't shrink

⏺ Update(code/apps/freedom-email-app/src/modules/mail-collection/components/MailThreadListItem.tsx)…
  ⎿  Updated code/apps/freedom-email-app/src/modules/mail-collection/components/MailThreadListItem.tsx with 3 additions and 3 removals
...

⏺ Fixed the issue in the email list where dates weren't shown when the sender name was too long. Made two key changes:

  1. Replaced the <span> with a Stack component that has proper overflow constraints
  2. Added flexShrink: 0 and minWidth: '5rem' to the date/time to ensure it never collapses

  The from name will now be truncated with ellipsis when needed, while the date/time will always be visible.