### PR TITLE
Implement log mode that would be readable in docker logs

### DIFF
--- a/code/backends/freedom-mail-host/src/main.ts
+++ b/code/backends/freedom-mail-host/src/main.ts
@@ -16,7 +16,7 @@ const main = makeAsyncResultFunc(
   [import.meta.filename],
   async (trace): PR<undefined> => {
     // Setup
-    setLogger(wrapLogger(console));
+    setLogger(wrapLogger(console, 'pretty-print'));
     await uncheckedResult(initApp(trace));
 
     // Start SMTP server for receiving emails directly

--- a/code/backends/freedom-store-api-server/src/main.ts
+++ b/code/backends/freedom-store-api-server/src/main.ts
@@ -17,7 +17,7 @@ const main = makeAsyncResultFunc(
   [import.meta.filename],
   async (trace): PR<undefined> => {
     // Setup
-    setLogger(wrapLogger(console));
+    setLogger(wrapLogger(console, 'pretty-print'));
     await uncheckedResult(initApp(trace));
 
     // Start the HTTP REST server

--- a/code/cross-platform-packages/freedom-contexts/src/internal/utils/makeStructuredLog.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/internal/utils/makeStructuredLog.ts
@@ -1,0 +1,105 @@
+import type { JsonValue } from 'yaschema';
+
+import { LogJson } from '../../types/LogJson.ts';
+import { isTrace } from '../../types/Trace.ts';
+import { getTraceStackWithAttachments } from '../../utils/getTraceStackWithAttachments.ts';
+
+type TypeOrDeferredType<T> = T | (() => T);
+type SingleOrArrayType<T> = T | T[];
+
+// TODO: unify with WrapLoggingFuncOptions
+export interface MakeStructuredLogOptions {
+  prefix?: TypeOrDeferredType<SingleOrArrayType<any>>;
+  suffix?: TypeOrDeferredType<SingleOrArrayType<any>>;
+}
+
+export interface StructuredLogObject {
+  time: string;
+  message: string;
+  traceIds: string[];
+  traceStacks: string[][];
+  [key: string]: JsonValue;
+}
+
+/**
+ * Create a structured log object by processing the provided parameters
+ * @param options - Prefix and suffix options
+ * @param params - Log parameters
+ * @returns A structured log object with processed parameters
+ */
+export const makeStructuredLog = ({ prefix, suffix }: MakeStructuredLogOptions = {}, ...params: any[]): StructuredLogObject => {
+  const structuredLogValues: Partial<StructuredLogObject> = {
+    time: new Date().toISOString()
+  };
+
+  const messageParts: any[] = [];
+
+  const traceIds = new Set<string>();
+  const traceStacks: string[][] = [];
+
+  const addArgs = (param: any) => {
+    if (param === undefined) {
+      return;
+    } else if (param instanceof LogJson) {
+      structuredLogValues[param.name] = param.value;
+    } else if (param instanceof Error) {
+      messageParts.push(param.toString());
+    } else if (isTrace(param)) {
+      traceIds.add(param.traceId);
+      traceStacks.push(getTraceStackWithAttachments(param));
+    } else if (Array.isArray(param)) {
+      if (param.length > 0) {
+        for (const subparam of param) {
+          addArgs(subparam);
+        }
+        messageParts.push(':');
+      }
+    } else if (typeof param === 'string') {
+      messageParts.push(param.replace(/[\r\n]/g, '    '));
+    } else {
+      try {
+        messageParts.push(JSON.stringify(param).replace(/[\r\n]/g, '    '));
+      } catch (_e) {
+        messageParts.push(String(param).replace(/[\r\n]/g, '    '));
+      }
+    }
+  };
+
+  if (prefix !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const thePrefix = typeof prefix === 'function' ? prefix() : prefix;
+    if (thePrefix !== undefined) {
+      if (Array.isArray(thePrefix)) {
+        for (const param of thePrefix) {
+          addArgs(param);
+        }
+      } else {
+        addArgs(thePrefix);
+      }
+    }
+  }
+
+  for (const param of params) {
+    addArgs(param);
+  }
+
+  if (suffix !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const theSuffix = typeof suffix === 'function' ? suffix() : suffix;
+    if (theSuffix !== undefined) {
+      if (Array.isArray(theSuffix)) {
+        for (const param of theSuffix) {
+          addArgs(param);
+        }
+      } else {
+        addArgs(theSuffix);
+      }
+    }
+  }
+
+  structuredLogValues.message = messageParts.join(' ');
+  structuredLogValues.traceIds = Array.from(traceIds);
+  structuredLogValues.traceStacks = traceStacks;
+
+  return structuredLogValues as StructuredLogObject; // Was partial
+};

--- a/code/cross-platform-packages/freedom-contexts/src/types/LoggingMode.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/types/LoggingMode.ts
@@ -1,4 +1,4 @@
 import { makeStringSubtypeArray } from 'yaschema';
 
-export const loggingModes = makeStringSubtypeArray('structured', 'flat', 'none');
+export const loggingModes = makeStringSubtypeArray('structured', 'flat', 'pretty-print', 'none');
 export type LoggingMode = (typeof loggingModes)[0];

--- a/code/cross-platform-packages/freedom-contexts/src/utils/wrapLoggingFunc.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/utils/wrapLoggingFunc.ts
@@ -1,12 +1,10 @@
-import type { JsonValue } from 'yaschema';
-
 import { defaultLoggingMode } from '../consts/logging.ts';
+import { makeStructuredLog } from '../internal/utils/makeStructuredLog.ts';
 import type { LoggingFunc } from '../types/LoggingFunc.ts';
 import type { LoggingMode } from '../types/LoggingMode.ts';
 import { LogJson } from '../types/LogJson.ts';
 import { isTrace } from '../types/Trace.ts';
 import { getTraceStack } from './getTraceStack.ts';
-import { getTraceStackWithAttachments } from './getTraceStackWithAttachments.ts';
 
 type TypeOrDeferredType<T> = T | (() => T);
 type SingleOrArrayType<T> = T | T[];
@@ -39,6 +37,9 @@ export function wrapLoggingFunc(
     case 'structured':
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       return makeStructuredLoggingFunc(loggingFunc, { prefix, suffix });
+    case 'pretty-print':
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      return makePrettyPrintLoggingFunc(loggingFunc, { prefix, suffix });
   }
 }
 
@@ -115,80 +116,73 @@ const makeFlatLoggingFunc =
   };
 
 const makeStructuredLoggingFunc =
-  (loggingFunc: LoggingFunc, { prefix, suffix }: Pick<WrapLoggingFuncOptions, 'prefix' | 'suffix'>): LoggingFunc =>
+  (loggingFunc: LoggingFunc, options: Pick<WrapLoggingFuncOptions, 'prefix' | 'suffix'>): LoggingFunc =>
   (...params: any[]) => {
-    const structuredLogValues: Record<string, JsonValue> = {
-      time: new Date().toISOString()
-    };
-
-    const messageParts: any[] = [];
-
-    const traceIds = new Set<string>();
-    const traceStacks: string[][] = [];
-
-    const addArgs = (param: any) => {
-      if (param === undefined) {
-        return;
-      } else if (param instanceof LogJson) {
-        structuredLogValues[param.name] = param.value;
-      } else if (param instanceof Error) {
-        messageParts.push(param.toString());
-      } else if (isTrace(param)) {
-        traceIds.add(param.traceId);
-        traceStacks.push(getTraceStackWithAttachments(param));
-      } else if (Array.isArray(param)) {
-        if (param.length > 0) {
-          for (const subparam of param) {
-            addArgs(subparam);
-          }
-          messageParts.push(':');
-        }
-      } else if (typeof param === 'string') {
-        messageParts.push(param.replace(/[\r\n]/g, '    '));
-      } else {
-        try {
-          messageParts.push(JSON.stringify(param).replace(/[\r\n]/g, '    '));
-        } catch (_e) {
-          messageParts.push(String(param).replace(/[\r\n]/g, '    '));
-        }
-      }
-    };
-
-    if (prefix !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const thePrefix = typeof prefix === 'function' ? prefix() : prefix;
-      if (thePrefix !== undefined) {
-        if (Array.isArray(thePrefix)) {
-          for (const param of thePrefix) {
-            addArgs(param);
-          }
-        } else {
-          addArgs(thePrefix);
-        }
-      }
-    }
-
-    for (const param of params) {
-      addArgs(param);
-    }
-
-    if (suffix !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const theSuffix = typeof suffix === 'function' ? suffix() : suffix;
-      if (theSuffix !== undefined) {
-        if (Array.isArray(theSuffix)) {
-          for (const param of theSuffix) {
-            addArgs(param);
-          }
-        } else {
-          addArgs(theSuffix);
-        }
-      }
-    }
-
-    structuredLogValues.message = messageParts.join(' ');
-    structuredLogValues.traceIds = Array.from(traceIds);
-    structuredLogValues.traceStacks = traceStacks;
-
-    loggingFunc(JSON.stringify(structuredLogValues));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: disable this rule globally - the types match
+    const logObject = makeStructuredLog(options, ...params);
+    loggingFunc(JSON.stringify(logObject));
   };
+
+const makePrettyPrintLoggingFunc =
+  (loggingFunc: LoggingFunc, options: Pick<WrapLoggingFuncOptions, 'prefix' | 'suffix'>): LoggingFunc =>
+  (...params: any[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: disable this rule globally - the types match
+    const logObject = makeStructuredLog(options, ...params);
+
+    // Extract main components
+    const { time, severity, message: msgContent, traceIds, traceStacks, ...rest } = logObject;
+
+    // Format the date to be more readable
+    const prettyTime = time.replace('T', ' ').replace('Z', '');
+
+    // Paint severity
+    let paintedSeverity;
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- TODO: check for rule updates, it seems broken
+    switch (severity) {
+      case 'ERROR':
+        paintedSeverity = '\x1b[31mERROR\x1b[0m'; // Red
+        break;
+      case 'WARNING':
+        paintedSeverity = '\x1b[33mWARNING\x1b[0m'; // Yellow
+        break;
+      case 'INFO':
+      case undefined: // <-- this is log().log?.(...)
+        paintedSeverity = '\x1b[34mINFO\x1b[0m'; // Blue
+        break;
+      case 'DEBUG':
+        paintedSeverity = '\x1b[90mDEBUG\x1b[0m'; // Gray
+        break;
+      default:
+        // It is not structured, so stringifying the unexpected values
+        paintedSeverity = JSON.stringify(severity);
+        break;
+    }
+
+    const lines = [
+      // Main line
+      `${prettyTime} - ${paintedSeverity} - ${msgContent || '[No message]'}`,
+      // Format traceIds as path
+      `  traceIds: ${traceIds.length === 0 ? '<root>' : traceIds.join('.')}`
+    ];
+
+    // Hide traceStacks, if empty
+    if (traceStacks.length > 0) {
+      lines.push(`  traceStacks: ${formatPrettyPrintValue(traceStacks)}`);
+    }
+
+    // Format the rest
+    Object.entries(rest).forEach(([key, value]) => {
+      lines.push(`  ${key}: ${formatPrettyPrintValue(value)}`);
+    });
+
+    loggingFunc(lines.join('\n'));
+  };
+
+const formatPrettyPrintValue = (value: any): string => {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value);
+  } else if (typeof value === 'object' && value !== null) {
+    return JSON.stringify(value);
+  }
+  return String(value);
+};


### PR DESCRIPTION
One concern: I've caught two eslint false-positives. Not addressing them now.

Decided not to use `chalk` - the scope of color codes is limited and they have not changed for decades. A comment is enough for readability.