### PR TITLE
Added invalidateAllInMemoryCaches to all test suites that needed it

### DIFF
--- a/code/cross-platform-packages/freedom-email-user/package.json
+++ b/code/cross-platform-packages/freedom-email-user/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "freedom-build-tools": "0.0.0",
+    "freedom-in-memory-cache": "0.0.0",
     "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"
   },

--- a/code/cross-platform-packages/freedom-email-user/src/__tests__/listTimeOrganizedMailIds.test.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/__tests__/listTimeOrganizedMailIds.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, it } from 'node:test';
 
 import { ONE_HOUR_MSEC } from 'freedom-basic-data';
 import { addMail, listTimeOrganizedMailIds } from 'freedom-email-sync';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import type { PageToken } from 'freedom-paginated-data';
 import { clearDocumentCache } from 'freedom-syncable-store';
 import { expectOk, expectStrictEqual } from 'freedom-testing-tools';
@@ -11,6 +12,7 @@ import { createInitialSyncableStoreStructureForUser } from '../utils/createIniti
 import { getUserMailPaths } from '../utils/getUserMailPaths.ts';
 
 describe('listTimeOrganizedMailIds', () => {
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   it('should work with no emails', async () => {

--- a/code/cross-platform-packages/freedom-email-user/src/__tests__/scenarios.test.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/__tests__/scenarios.test.ts
@@ -2,14 +2,16 @@ import { strict as assert } from 'node:assert';
 import { afterEach, describe, test } from 'node:test';
 
 import { addMail, getOutboundMailById, listOutboundMailIds, moveOutboundMailToStorage } from 'freedom-email-sync';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { clearDocumentCache, createBundleAtPath, createFolderAtPath } from 'freedom-syncable-store';
 
 import { createEmailStoreTestStack } from '../__test_dependency__/createEmailStoreTestStack.ts';
 import { addMailDraft, getMailDraftById, getUserMailPaths, moveMailDraftToOutbox } from '../utils/exports.ts';
 
-afterEach(clearDocumentCache);
-
 describe('Inbound email routes', () => {
+  afterEach(invalidateAllInMemoryCaches);
+  afterEach(clearDocumentCache);
+
   // Note: always from external address
 
   // Data sample
@@ -47,6 +49,9 @@ describe('Inbound email routes', () => {
 });
 
 describe('Outbound email routes', () => {
+  afterEach(invalidateAllInMemoryCaches);
+  afterEach(clearDocumentCache);
+
   test('Full external address outbound', async () => {
     // Arrange
     const { trace, store, access } = await createEmailStoreTestStack();

--- a/code/cross-platform-packages/freedom-email-user/src/__tests__/traverseTimeOrganizedMailStorageFromTheBottomUp.test.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/__tests__/traverseTimeOrganizedMailStorageFromTheBottomUp.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from 'node:test';
 import { makeSuccess, type PR } from 'freedom-async';
 import type { BottomUpMailStorageTraversalResult } from 'freedom-email-sync';
 import { addMail, traverseTimeOrganizedMailStorageFromTheBottomUp } from 'freedom-email-sync';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { clearDocumentCache } from 'freedom-syncable-store';
 import { expectDeepStrictEqual, expectOk } from 'freedom-testing-tools';
 
@@ -11,6 +12,7 @@ import { createInitialSyncableStoreStructureForUser } from '../utils/createIniti
 import { getUserMailPaths } from '../utils/getUserMailPaths.ts';
 
 describe('traverseTimeOrganizedMailStorageFromTheBottomUp', () => {
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   it('should work with no emails', async () => {

--- a/code/cross-platform-packages/freedom-in-memory-cache/src/classes/__tests__/InMemoryCache.test.ts
+++ b/code/cross-platform-packages/freedom-in-memory-cache/src/classes/__tests__/InMemoryCache.test.ts
@@ -1,10 +1,12 @@
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 
 import { expectStrictEqual, sleep } from 'freedom-testing-tools';
 
-import { InMemoryCache } from '../InMemoryCache.ts';
+import { InMemoryCache, invalidateAllInMemoryCaches } from '../InMemoryCache.ts';
 
 describe('InMemoryCache', () => {
+  afterEach(invalidateAllInMemoryCaches);
+
   it('getting and setting should work', async () => {
     const cache = new InMemoryCache<string, number>({ cacheDurationMSec: 500, shouldResetIntervalOnGet: true });
 
@@ -216,5 +218,23 @@ describe('InMemoryCache', () => {
 
       expectStrictEqual(cache.get(owner, 'key'), undefined);
     }
+  });
+
+  it('invalidateAllInMemoryCaches should work', async () => {
+    const cache = new InMemoryCache<string, number>({ cacheDurationMSec: 60000, shouldResetIntervalOnGet: true });
+
+    const owner = {};
+
+    expectStrictEqual(cache.get(owner, 'key'), undefined);
+    cache.set(owner, 'key', 3.14);
+    expectStrictEqual(cache.get(owner, 'key'), 3.14);
+
+    await sleep(50);
+
+    expectStrictEqual(cache.get(owner, 'key'), 3.14);
+
+    invalidateAllInMemoryCaches();
+
+    expectStrictEqual(cache.get(owner, 'key'), undefined);
   });
 });

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/types/__tests__/folders.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/types/__tests__/folders.test.ts
@@ -6,6 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, syncableItemTypes, uuidId } from 'freedom-sync-types';
 import { ACCESS_CONTROL_BUNDLE_ID, saltedId, STORE_CHANGES_BUNDLE_ID } from 'freedom-syncable-store-types';
@@ -35,6 +36,7 @@ describe('folders', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async () => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/types/__tests__/hashes.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/types/__tests__/hashes.test.ts
@@ -6,6 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
@@ -28,6 +29,7 @@ describe('hashes', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async (_t: TestContext | SuiteContext) => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/types/__tests__/DefaultSyncableStore.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/types/__tests__/DefaultSyncableStore.test.ts
@@ -1,6 +1,7 @@
 import type { TestContext } from 'node:test';
 import { afterEach, describe, it } from 'node:test';
 
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { encName, uuidId } from 'freedom-sync-types';
 import { expectErrorCode, expectIncludes, expectOk } from 'freedom-testing-tools';
 
@@ -14,6 +15,7 @@ import { getMutableFolderAtPath } from '../../utils/get/getMutableFolderAtPath.t
 import { getStringFromFile } from '../../utils/get/getStringFromFile.ts';
 
 describe('DefaultSyncableStore', () => {
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   it('deleting files and folders should work', async (t: TestContext) => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createConflictFreeDocumentBundleAtPath.test.ts
@@ -8,6 +8,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import type { ConflictFreeDocumentEvaluator } from 'freedom-syncable-store-types';
@@ -31,6 +32,7 @@ describe('createConflictFreeDocumentBundleAtPath', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async () => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createJsonFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createJsonFileAtPath.test.ts
@@ -6,6 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
@@ -31,6 +32,7 @@ describe('createJsonFileAtPath', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async () => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createStringFileAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/createStringFileAtPath.test.ts
@@ -6,6 +6,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import { expectOk } from 'freedom-testing-tools';
@@ -28,6 +29,7 @@ describe('createStringFileAtPath', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async () => {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/getConflictFreeDocumentBundleAtPath.test.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/__tests__/getConflictFreeDocumentBundleAtPath.test.ts
@@ -8,6 +8,7 @@ import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { InMemorySyncableStoreBacking } from 'freedom-in-memory-syncable-store-backing';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, uuidId } from 'freedom-sync-types';
 import type { ConflictFreeDocumentEvaluator } from 'freedom-syncable-store-types';
@@ -30,6 +31,7 @@ describe('getConflictFreeDocumentBundleAtPath', () => {
 
   const storageRootId = storageRootIdInfo.make('test');
 
+  afterEach(invalidateAllInMemoryCaches);
   afterEach(clearDocumentCache);
 
   beforeEach(async () => {

--- a/code/server-packages/freedom-file-system-syncable-store-backing/package.json
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/package.json
@@ -21,6 +21,7 @@
     "freedom-crypto": "0.0.0",
     "freedom-crypto-data": "0.0.0",
     "freedom-crypto-service": "0.0.0",
+    "freedom-in-memory-cache": "0.0.0",
     "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"
   },

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/types/__tests__/FileSystemSyncableStoreBacking.test.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/types/__tests__/FileSystemSyncableStoreBacking.test.ts
@@ -2,13 +2,14 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { TestContext } from 'node:test';
-import { before, beforeEach, describe, it } from 'node:test';
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import type { Trace } from 'freedom-contexts';
 import { makeTrace, makeUuid } from 'freedom-contexts';
 import { generateCryptoCombinationKeySet } from 'freedom-crypto';
 import type { PrivateCombinationCryptoKeySet } from 'freedom-crypto-data';
 import type { CryptoService } from 'freedom-crypto-service';
+import { invalidateAllInMemoryCaches } from 'freedom-in-memory-cache';
 import { DEFAULT_SALT_ID, encName, storageRootIdInfo, syncableItemTypes, uuidId } from 'freedom-sync-types';
 import {
   createBinaryFileAtPath,
@@ -32,6 +33,8 @@ import { makeHotSwappableCryptoServiceForTesting } from '../../__test_dependency
 import { FileSystemSyncableStoreBacking } from '../FileSystemSyncableStoreBacking.ts';
 
 describe('FileSystemSyncableStore', () => {
+  afterEach(invalidateAllInMemoryCaches);
+
   let trace!: Trace;
   let privateKeys!: PrivateCombinationCryptoKeySet;
   let cryptoService!: HotSwappableCryptoService;


### PR DESCRIPTION
- invalidateAllInMemoryCaches is replacing clearDocumentCache soon, but for now, doing both in some places
- tracking which InMemoryCache instances are non-empty so we can easily access the list and invalidate everything without having a memory leak