### PR TITLE
Async Docs

### DIFF
--- a/code/backends/freedom-mail-host/package.json
+++ b/code/backends/freedom-mail-host/package.json
@@ -5,7 +5,9 @@
     "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-db": "0.0.0",
+    "freedom-email-server": "0.0.0",
     "freedom-email-sync": "0.0.0",
+    "freedom-syncable-store-server": "0.0.0",
     "mailparser": "3.7.2",
     "nodemailer": "6.10.1",
     "smtp-server": "3.13.6"

--- a/code/cross-platform-packages/freedom-access-control/src/__test_dependency__/TestAccessControlDocument.ts
+++ b/code/cross-platform-packages/freedom-access-control/src/__test_dependency__/TestAccessControlDocument.ts
@@ -1,6 +1,6 @@
 /* node:coverage disable */
 
-import type { AccessControlDocumentPrefix, InitialAccess } from 'freedom-access-control-types';
+import type { AccessControlDocumentPrefix } from 'freedom-access-control-types';
 import { AccessControlDocument } from 'freedom-access-control-types';
 import type { PR } from 'freedom-async';
 import { makeAsyncResultFunc, makeSuccess } from 'freedom-async';
@@ -12,18 +12,20 @@ export type TestRole = (typeof testStoreRoles)[0];
 export const testStoreRoleSchema = schema.string(...testStoreRoles);
 
 export class TestAccessControlDocument extends AccessControlDocument<TestRole> {
-  constructor(
-    fwd:
-      | { initialAccess: InitialAccess<TestRole>; snapshot?: undefined }
-      | { initialAccess?: undefined; snapshot: { id: string; encoded: EncodedConflictFreeDocumentSnapshot<AccessControlDocumentPrefix> } }
-  ) {
+  constructor(fwd?: { snapshot?: { id: string; encoded: EncodedConflictFreeDocumentSnapshot<AccessControlDocumentPrefix> } }) {
     super({ roleSchema: testStoreRoleSchema, ...fwd });
   }
 
   // Overridden Public Methods
 
-  public override clone(out?: TestAccessControlDocument): TestAccessControlDocument {
-    return super.clone(out ?? new TestAccessControlDocument({ initialAccess: this.initialAccess_ })) as TestAccessControlDocument;
+  public override async clone(out?: TestAccessControlDocument): Promise<TestAccessControlDocument> {
+    if (out === undefined) {
+      return (await super.clone(out)) as TestAccessControlDocument;
+    } else {
+      const doc = new TestAccessControlDocument();
+      await doc.initialize({ access: await this.initialAccess_ });
+      return (await super.clone(doc)) as TestAccessControlDocument;
+    }
   }
 
   // Public Methods

--- a/code/cross-platform-packages/freedom-access-control/src/utils/__tests__/generateSignedAddAccessChange.test.ts
+++ b/code/cross-platform-packages/freedom-access-control/src/utils/__tests__/generateSignedAddAccessChange.test.ts
@@ -34,11 +34,13 @@ describe('generateSignedAddAccessChange', () => {
 
     expectDeepStrictEqual(deserializedInitialAccessState.value, { [cryptoKeys1.value.id]: 'creator' });
 
-    const accessControlDoc = new TestAccessControlDocument({ initialAccess: initialAccess.value });
+    const accessControlDoc = new TestAccessControlDocument();
+    await accessControlDoc.initialize({ access: initialAccess.value });
 
-    expectDeepStrictEqual(await accessControlDoc.accessControlState, {
-      [cryptoKeys1.value.id]: 'creator'
-    });
+    const accessControlState1 = await accessControlDoc.getAccessControlState(trace);
+    expectOk(accessControlState1);
+
+    expectDeepStrictEqual(accessControlState1.value, { [cryptoKeys1.value.id]: 'creator' });
 
     const cryptoKeys2 = await generateCryptoCombinationKeySet(trace);
     expectOk(cryptoKeys2);
@@ -61,7 +63,10 @@ describe('generateSignedAddAccessChange', () => {
     const accessAdded = await accessControlDoc.addChange(trace, signedAddAccessChange.value.signedAccessChange);
     expectOk(accessAdded);
 
-    expectDeepStrictEqual(await accessControlDoc.accessControlState, {
+    const accessControlState2 = await accessControlDoc.getAccessControlState(trace);
+    expectOk(accessControlState2);
+
+    expectDeepStrictEqual(accessControlState2.value, {
       [cryptoKeys1.value.id]: 'creator',
       [cryptoKeys2.value.id]: 'editor'
     });

--- a/code/cross-platform-packages/freedom-access-control/src/utils/__tests__/generateSignedModifyAccessChange.test.ts
+++ b/code/cross-platform-packages/freedom-access-control/src/utils/__tests__/generateSignedModifyAccessChange.test.ts
@@ -47,7 +47,8 @@ describe('generateSignedModifyAccessChange', () => {
 
     assert.deepStrictEqual(deserializedInitialAccessState.value, { [cryptoKeys1.id]: 'creator' });
 
-    accessControlDoc = new TestAccessControlDocument({ initialAccess: initialAccess.value });
+    accessControlDoc = new TestAccessControlDocument();
+    await accessControlDoc.initialize({ access: initialAccess.value });
 
     const internalCryptoKeys2 = await generateCryptoCombinationKeySet(trace);
     expectOk(internalCryptoKeys2);
@@ -95,7 +96,10 @@ describe('generateSignedModifyAccessChange', () => {
     const accessModified = await accessControlDoc.addChange(trace, signedModifyAccessChange.value.signedAccessChange);
     expectOk(accessModified);
 
-    expectDeepStrictEqual(await accessControlDoc.accessControlState, {
+    const accessControlState = await accessControlDoc.getAccessControlState(trace);
+    expectOk(accessControlState);
+
+    expectDeepStrictEqual(accessControlState.value, {
       [cryptoKeys1.id]: 'creator',
       [cryptoKeys2.id]: 'viewer'
     });
@@ -150,7 +154,10 @@ describe('generateSignedModifyAccessChange', () => {
     const accessModified = await accessControlDoc.addChange(trace, signedModifyAccessChange.value.signedAccessChange);
     expectOk(accessModified);
 
-    expectDeepStrictEqual(await accessControlDoc.accessControlState, {
+    const accessControlState = await accessControlDoc.getAccessControlState(trace);
+    expectOk(accessControlState);
+
+    expectDeepStrictEqual(accessControlState.value, {
       [cryptoKeys1.id]: 'creator',
       [cryptoKeys2.id]: 'appender'
     });
@@ -205,7 +212,10 @@ describe('generateSignedModifyAccessChange', () => {
     const accessModified = await accessControlDoc.addChange(trace, signedModifyAccessChange.value.signedAccessChange);
     expectOk(accessModified);
 
-    expectDeepStrictEqual(await accessControlDoc.accessControlState, {
+    const accessControlState = await accessControlDoc.getAccessControlState(trace);
+    expectOk(accessControlState);
+
+    expectDeepStrictEqual(accessControlState.value, {
       [cryptoKeys1.id]: 'creator',
       [cryptoKeys2.id]: 'viewer'
     });

--- a/code/cross-platform-packages/freedom-access-control/src/utils/generateSignedModifyAccessChange.ts
+++ b/code/cross-platform-packages/freedom-access-control/src/utils/generateSignedModifyAccessChange.ts
@@ -79,8 +79,14 @@ export const generateSignedModifyAccessChange = makeAsyncResultFunc(
       } else {
         // If the user is losing read access, we need to create a new set of shared keys (and could eventually reencrypt old data)
 
+        const accessControlState = await accessControlDoc.getAccessControlState(trace);
+        if (!accessControlState.ok) {
+          return accessControlState;
+        }
+
         const usersWithReadAccessEncryptingKeySets: EncryptingKeySet[] = [];
-        for (const [publicKeyId, role] of objectEntries(await accessControlDoc.accessControlState)) {
+
+        for (const [publicKeyId, role] of objectEntries(accessControlState.value)) {
           if (publicKeyId === params.publicKeyId) {
             continue; // Skip the user we're modifying, since we know they're losing read access
           } else if (role === undefined) {

--- a/code/cross-platform-packages/freedom-async/src/classes/AsyncTransient.ts
+++ b/code/cross-platform-packages/freedom-async/src/classes/AsyncTransient.ts
@@ -1,0 +1,21 @@
+import type { Trace } from 'freedom-contexts';
+
+export class AsyncTransient<T> {
+  private getValue_: (trace: Trace) => Promise<T>;
+  constructor(getValue: (trace: Trace) => Promise<T>) {
+    this.getValue_ = getValue;
+  }
+
+  private valuePromise_: Promise<T> | undefined;
+  public getValue(trace: Trace): Promise<T> {
+    if (this.valuePromise_ === undefined) {
+      this.valuePromise_ = this.getValue_(trace);
+    }
+
+    return this.valuePromise_;
+  }
+
+  public markNeedsUpdate() {
+    this.valuePromise_ = undefined;
+  }
+}

--- a/code/cross-platform-packages/freedom-async/src/classes/__tests__/AsyncTransient.test.ts
+++ b/code/cross-platform-packages/freedom-async/src/classes/__tests__/AsyncTransient.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+
+import { makeTrace } from 'freedom-contexts';
+import { expectStrictEqual } from 'freedom-testing-tools';
+
+import { sleep } from '../../utils/sleep.ts';
+import { AsyncTransient } from '../AsyncTransient.ts';
+
+describe('AsyncTransient', () => {
+  it('should work', async () => {
+    const trace = makeTrace('test');
+
+    let callCount = 0;
+    const transient = new AsyncTransient(async () => {
+      sleep(50);
+      callCount += 1;
+      return callCount;
+    });
+
+    expectStrictEqual(await transient.getValue(trace), 1);
+    expectStrictEqual(await transient.getValue(trace), 1);
+    transient.markNeedsUpdate();
+    expectStrictEqual(await transient.getValue(trace), 2);
+  });
+});

--- a/code/cross-platform-packages/freedom-async/src/classes/exports.ts
+++ b/code/cross-platform-packages/freedom-async/src/classes/exports.ts
@@ -1,0 +1,1 @@
+export * from './AsyncTransient.ts';

--- a/code/cross-platform-packages/freedom-async/src/exports.ts
+++ b/code/cross-platform-packages/freedom-async/src/exports.ts
@@ -1,5 +1,6 @@
 import { buildMode } from 'freedom-contexts';
 
+export * from './classes/exports.ts';
 export * from './config/exports.ts';
 export * from './consts/exports.ts';
 export * from './contexts/exports.ts';

--- a/code/cross-platform-packages/freedom-conflict-free-document/package.json
+++ b/code/cross-platform-packages/freedom-conflict-free-document/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/lodash-es": "4.17.12",
     "freedom-build-tools": "0.0.0",
+    "freedom-testing-tools": "0.0.0",
     "typescript": "5.8.3"
   },
   "type": "module",

--- a/code/cross-platform-packages/freedom-conflict-free-document/src/types/ConflictFreeDocument.ts
+++ b/code/cross-platform-packages/freedom-conflict-free-document/src/types/ConflictFreeDocument.ts
@@ -83,7 +83,7 @@ export class ConflictFreeDocument<PrefixT extends string> implements Notifiable<
 
   /** If no output document is specified, the cloned document will have the same id as this document.  One may call like
    * `clone(new ConflictFreeDocument('new-id'))` to clone but with a new document ID. */
-  public clone(out?: ConflictFreeDocument<PrefixT>): ThisType<PrefixT> {
+  public async clone(out?: ConflictFreeDocument<PrefixT>): Promise<ThisType<PrefixT>> {
     const cloned = out ?? new ConflictFreeDocument<PrefixT>(this.prefix);
     cloned.#yDoc = cloneYDoc(this.#yDoc);
     cloned.#deltaBasisYDoc = cloneYDoc(this.#deltaBasisYDoc);

--- a/code/cross-platform-packages/freedom-conflict-free-document/src/types/__test_dependency__/ConflictFreeTestDocument.ts
+++ b/code/cross-platform-packages/freedom-conflict-free-document/src/types/__test_dependency__/ConflictFreeTestDocument.ts
@@ -32,8 +32,8 @@ export class ConflictFreeTestDocument extends ConflictFreeDocument<'TEST'> {
 
   // Overridden Public Methods
 
-  public override clone(out?: ConflictFreeTestDocument): ConflictFreeTestDocument {
-    return super.clone(out ?? new ConflictFreeTestDocument()) as ConflictFreeTestDocument;
+  public override async clone(out?: ConflictFreeTestDocument): Promise<ConflictFreeTestDocument> {
+    return (await super.clone(out ?? new ConflictFreeTestDocument())) as ConflictFreeTestDocument;
   }
 
   // Field Access Methods

--- a/code/cross-platform-packages/freedom-conflict-free-document/src/types/__tests__/ConflictFreeDocument.test.ts
+++ b/code/cross-platform-packages/freedom-conflict-free-document/src/types/__tests__/ConflictFreeDocument.test.ts
@@ -296,11 +296,11 @@ describe('ConflictFreeDocument', () => {
   });
 
   describe('clone', () => {
-    it('should work', (t: TestContext) => {
+    it('should work', async (t: TestContext) => {
       const doc = new ConflictFreeTestDocument();
       doc.title.replace(0, 'hello');
 
-      const doc2 = doc.clone();
+      const doc2 = await doc.clone();
       t.assert.strictEqual(doc2.title.getString(), 'hello');
     });
   });
@@ -345,11 +345,11 @@ describe('ConflictFreeDocument', () => {
   });
 
   describe('deltas', () => {
-    it('regular deltas should work', (t: TestContext) => {
+    it('regular deltas should work', async (t: TestContext) => {
       const doc = new ConflictFreeTestDocument();
       doc.title.replace(0, 'hello');
 
-      const doc2 = doc.clone();
+      const doc2 = await doc.clone();
 
       doc.title.replace(5, ' world');
       doc.age.set(6.28);
@@ -365,11 +365,11 @@ describe('ConflictFreeDocument', () => {
       t.assert.deepStrictEqual(doc2.meta.get(), { name: 'Testing', age: 25 });
     });
 
-    it('diff should work', (t: TestContext) => {
+    it('diff should work', async (t: TestContext) => {
       const doc = new ConflictFreeTestDocument();
       doc.title.replace(0, 'hello');
 
-      const doc2 = doc.clone();
+      const doc2 = await doc.clone();
 
       doc.title.replace(5, ' world');
 
@@ -381,11 +381,11 @@ describe('ConflictFreeDocument', () => {
       t.assert.strictEqual(doc2.title.getString(), 'hello world');
     });
 
-    it('merge should work', (t: TestContext) => {
+    it('merge should work', async (t: TestContext) => {
       const doc = new ConflictFreeTestDocument();
       doc.title.replace(0, 'hello');
 
-      const doc2 = doc.clone();
+      const doc2 = await doc.clone();
 
       doc.title.replace(5, ' world');
 

--- a/code/cross-platform-packages/freedom-email-user/src/types/MailCollectionMetaDocument.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/types/MailCollectionMetaDocument.ts
@@ -11,8 +11,8 @@ export class MailCollectionMetaDocument extends ConflictFreeDocument<MailCollect
 
   // Overridden Public Methods
 
-  public override clone(out?: MailCollectionMetaDocument): MailCollectionMetaDocument {
-    return super.clone(out ?? new MailCollectionMetaDocument()) as MailCollectionMetaDocument;
+  public override async clone(out?: MailCollectionMetaDocument): Promise<MailCollectionMetaDocument> {
+    return (await super.clone(out ?? new MailCollectionMetaDocument())) as MailCollectionMetaDocument;
   }
 
   // Field Access Methods

--- a/code/cross-platform-packages/freedom-email-user/src/types/MailDraftDocument.ts
+++ b/code/cross-platform-packages/freedom-email-user/src/types/MailDraftDocument.ts
@@ -28,8 +28,8 @@ export class MailDraftDocument extends ConflictFreeDocument<MailDraftDocumentPre
 
   // Overridden Public Methods
 
-  public override clone(out?: MailDraftDocument): MailDraftDocument {
-    return super.clone(out ?? new MailDraftDocument()) as MailDraftDocument;
+  public override async clone(out?: MailDraftDocument): Promise<MailDraftDocument> {
+    return (await super.clone(out ?? new MailDraftDocument())) as MailDraftDocument;
   }
 
   // ConflictFreeDocumentEvaluator Methods

--- a/code/cross-platform-packages/freedom-syncable-store-types/src/types/ISyncableStoreAccessControlDocument.ts
+++ b/code/cross-platform-packages/freedom-syncable-store-types/src/types/ISyncableStoreAccessControlDocument.ts
@@ -4,5 +4,5 @@ import type { CryptoKeySetId } from 'freedom-crypto-data';
 import type { SyncableStoreRole } from './SyncableStoreRole.ts';
 
 export interface ISyncableStoreAccessControlDocument extends AccessControlDocument<SyncableStoreRole> {
-  readonly creatorCryptoKeySetId: CryptoKeySetId | undefined;
+  readonly creatorCryptoKeySetId: Promise<CryptoKeySetId | undefined>;
 }

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/types/DefaultMutableSyncableFolderAccessorBase.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/types/DefaultMutableSyncableFolderAccessorBase.ts
@@ -599,7 +599,7 @@ export abstract class DefaultMutableSyncableFolderAccessorBase implements Mutabl
       }
       /* node:coverage enable */
 
-      return makeSuccess(await accessControlDoc.value.accessControlState);
+      return await accessControlDoc.value.getAccessControlState(trace);
     }
   );
 

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/types/FolderOperationsHandler.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/types/FolderOperationsHandler.ts
@@ -86,7 +86,7 @@ export class FolderOperationsHandler {
         return makeSuccess(false);
       }
 
-      return makeSuccess(storeChangesDoc.value.document.isDeletedPath(path));
+      return await storeChangesDoc.value.document.isDeletedPath(trace, path);
     }
   );
 

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createConflictFreeDocumentBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createConflictFreeDocumentBundleAtPath.ts
@@ -7,6 +7,7 @@ import type { DynamicSyncableItemName, SyncableOriginOptions, SyncablePath } fro
 import { isSyncableItemEncrypted, timeId } from 'freedom-sync-types';
 import type { MutableSyncableStore } from 'freedom-syncable-store-types';
 import { makeDeltasBundleId, SNAPSHOTS_BUNDLE_ID } from 'freedom-syncable-store-types';
+import type { TypeOrPromisedType } from 'yaschema';
 
 import { createBundleAtPath } from './createBundleAtPath.ts';
 import { createStringFileAtPath } from './createStringFileAtPath.ts';
@@ -22,7 +23,7 @@ export const createConflictFreeDocumentBundleAtPath = makeAsyncResultFunc(
       trustedTimeSignature,
       newDocument
     }: Partial<SyncableOriginOptions> & {
-      newDocument: () => DocumentT;
+      newDocument: () => TypeOrPromisedType<DocumentT>;
       name?: DynamicSyncableItemName;
     }
   ): PR<undefined, 'conflict' | 'deleted' | 'not-found' | 'untrusted' | 'wrong-type'> => {
@@ -59,7 +60,7 @@ export const createConflictFreeDocumentBundleAtPath = makeAsyncResultFunc(
     }
     /* node:coverage enable */
 
-    const document = newDocument();
+    const document = await newDocument();
     const encodedSnapshot = document.encodeSnapshot(initialSnapshotId);
 
     const savedSnapshot = await createStringFileAtPath(trace, store, snapshotsPath.append(initialSnapshotId), {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
@@ -354,7 +354,7 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
                     return makeFailure(new ForbiddenError(trace, { message: 'No role found' }));
                   }
 
-                  const deltaValid = await isDeltaValidForDocument(trace, document.clone() as DocumentT, {
+                  const deltaValid = await isDeltaValidForDocument(trace, (await document.clone()) as DocumentT, {
                     store,
                     path: deltaFile.value.path,
                     validatedProvenance: deltaProvenance.value,

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/validation/getRoleForOrigin.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/validation/getRoleForOrigin.ts
@@ -20,8 +20,11 @@ export const getRoleForOrigin = makeAsyncResultFunc(
       return makeSuccess('creator' as const);
     }
 
-    const accessControlState = await accessControlDoc.accessControlState;
+    const accessControlState = await accessControlDoc.getAccessControlState(trace);
+    if (!accessControlState.ok) {
+      return accessControlState;
+    }
 
-    return makeSuccess(accessControlState[signedByKeyId.value]);
+    return makeSuccess(accessControlState.value[signedByKeyId.value]);
   }
 );

--- a/code/server-packages/freedom-db/package.json
+++ b/code/server-packages/freedom-db/package.json
@@ -6,6 +6,7 @@
     "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-crypto-data": "0.0.0",
+    "freedom-crypto-service": "0.0.0",
     "freedom-email-sync": "0.0.0",
     "freedom-json-file-object-store": "0.0.0",
     "freedom-object-store-types": "0.0.0",

--- a/code/server-packages/freedom-email-server/package.json
+++ b/code/server-packages/freedom-email-server/package.json
@@ -1,23 +1,11 @@
 {
   "dependencies": {
-    "freedom-access-control-types": "0.0.0",
     "freedom-async": "0.0.0",
-    "freedom-basic-data": "0.0.0",
-    "freedom-conflict-free-document-data": "0.0.0",
-    "freedom-conflict-free-document": "0.0.0",
+    "freedom-common-errors": "0.0.0",
     "freedom-contexts": "0.0.0",
-    "freedom-crypto-data": "0.0.0",
-    "freedom-crypto-service": "0.0.0",
-    "freedom-crypto": "0.0.0",
     "freedom-db": "0.0.0",
-    "freedom-dev-logging-support": "0.0.0",
     "freedom-email-sync": "0.0.0",
-    "freedom-notification-types": "0.0.0",
-    "freedom-sync-types": "0.0.0",
-    "freedom-syncable-store-backing-types": "0.0.0",
-    "freedom-syncable-store-server": "0.0.0",
-    "freedom-trusted-time-source": "0.0.0",
-    "yaschema": "5.0.0"
+    "freedom-syncable-store-server": "0.0.0"
   },
   "devDependencies": {
     "freedom-build-tools": "0.0.0",

--- a/code/server-packages/freedom-syncable-store-server/package.json
+++ b/code/server-packages/freedom-syncable-store-server/package.json
@@ -1,21 +1,17 @@
 {
   "dependencies": {
-    "freedom-access-control-types": "0.0.0",
     "freedom-async": "0.0.0",
     "freedom-basic-data": "0.0.0",
     "freedom-common-errors": "0.0.0",
+    "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-crypto": "0.0.0",
     "freedom-crypto-data": "0.0.0",
-    "freedom-crypto-service": "0.0.0",
     "freedom-db": "0.0.0",
-    "freedom-dev-logging-support": "0.0.0",
     "freedom-email-sync": "0.0.0",
     "freedom-file-system-syncable-store-backing": "0.0.0",
     "freedom-sync-types": "0.0.0",
-    "freedom-syncable-store": "0.0.0",
-    "freedom-syncable-store-types": "0.0.0",
-    "yaschema": "5.0.0"
+    "freedom-syncable-store": "0.0.0"
   },
   "devDependencies": {
     "freedom-build-tools": "0.0.0",


### PR DESCRIPTION
- AccessControlDocument now uses async crdt fields for initialState_, initialPublicKeysById_, and changes_
- Added AsyncTransient class for computing async cached data (for a single "field" that might need to be invalidated semi-frequently)
- Other document changes to support async