### PR TITLE
Improved disableLam

### DIFF
--- a/code/backends/freedom-store-api-server/src/api-handlers/check-name-availability.ts
+++ b/code/backends/freedom-store-api-server/src/api-handlers/check-name-availability.ts
@@ -19,7 +19,7 @@ export default makeHttpApiHandler(
   ) => {
     // Check if the name is already taken by constructing the email
     const email = `${name}@${config.EMAIL_DOMAIN}`;
-    const existingUserResult = await disableLam(trace, 'not-found', (trace) => findUserByEmail(trace, email));
+    const existingUserResult = await disableLam('not-found', findUserByEmail)(trace, email);
 
     // Expected outcomes
     if (existingUserResult.ok || existingUserResult.value.errorCode === 'not-found') {

--- a/code/backends/freedom-store-api-server/src/api-handlers/pull.ts
+++ b/code/backends/freedom-store-api-server/src/api-handlers/pull.ts
@@ -10,7 +10,7 @@ import { pullPath } from 'freedom-syncable-store';
 
 export default makeHttpApiHandler(
   [import.meta.filename],
-  { api: api.pull.POST, disableLam: 'not-found' },
+  { api: api.pull.POST, deepDisableLam: 'not-found' },
   async (trace, { input: { body: args } }) => {
     const userId = emailUserIdInfo.checked(storageRootIdInfo.removePrefix(args.path.storageRootId));
     if (userId === undefined) {

--- a/code/backends/freedom-store-api-server/src/api-handlers/push.ts
+++ b/code/backends/freedom-store-api-server/src/api-handlers/push.ts
@@ -10,7 +10,7 @@ import { pushPath } from 'freedom-syncable-store';
 
 export default makeHttpApiHandler(
   [import.meta.filename],
-  { api: api.push.POST, disableLam: 'not-found' },
+  { api: api.push.POST, deepDisableLam: 'not-found' },
   async (trace, { input: { body: args } }) => {
     const userId = emailUserIdInfo.checked(storageRootIdInfo.removePrefix(args.path.storageRootId));
     if (userId === undefined) {

--- a/code/backends/freedom-store-api-server/src/api-handlers/register.ts
+++ b/code/backends/freedom-store-api-server/src/api-handlers/register.ts
@@ -63,12 +63,7 @@ export default makeHttpApiHandler(
         // Create user's syncable store
         // Conflicts are expected to happen here sometimes because registration is attempted every time a client starts its sync service
         // (because it can't otherwise knows the state of registration on the server)
-        const createSyncableStoreResult = await disableLam(trace, 'conflict', (trace) =>
-          createSyncableStore(trace, {
-            storageRootId,
-            metadata
-          })
-        );
+        const createSyncableStoreResult = await disableLam('conflict', createSyncableStore)(trace, { storageRootId, metadata });
         if (!createSyncableStoreResult.ok) {
           return createSyncableStoreResult;
         }

--- a/code/cross-platform-packages/freedom-async/src/types/FuncOptions.ts
+++ b/code/cross-platform-packages/freedom-async/src/types/FuncOptions.ts
@@ -5,6 +5,8 @@ export interface FuncOptions<ReturnT, SpecialCallbackReturnT extends TypeOrPromi
   /** Specify error types or strings for error codes, to disable conditionally for logging and metrics.  Example:
    * `[UserAuthenticationError, 'username-already-taken']` */
   disableLam?: DisableErrorsForLoggingAndMetrics;
+  /** Like `disableLam` but affects all recursive calls as well */
+  deepDisableLam?: DisableErrorsForLoggingAndMetrics;
 
   /** Called when the function is first called */
   onStart?: () => SpecialCallbackReturnT;

--- a/code/cross-platform-packages/freedom-async/src/types/GeneralError.ts
+++ b/code/cross-platform-packages/freedom-async/src/types/GeneralError.ts
@@ -1,5 +1,4 @@
 import type { Trace } from 'freedom-contexts';
-import { get } from 'lodash-es';
 
 import { TraceableError } from './TraceableError.ts';
 
@@ -11,20 +10,11 @@ export class GeneralError<ErrorCodeT extends string = never> extends TraceableEr
       /* node:coverage ignore next */
       message: originalThrown instanceof Error ? originalThrown.message : 'Error',
       logLevel: 'warn',
-      errorCode
+      errorCode,
+      jsStack: originalThrown instanceof Error ? originalThrown.stack : undefined
     });
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.originalThrown = originalThrown;
-  }
-
-  protected override newErrorMessageSuffix(): string | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const stack = get(this.originalThrown, 'stack');
-    if (typeof stack === 'string') {
-      return stack;
-    }
-
-    return undefined;
   }
 }

--- a/code/cross-platform-packages/freedom-async/src/utils/callSyncFunc.ts
+++ b/code/cross-platform-packages/freedom-async/src/utils/callSyncFunc.ts
@@ -57,16 +57,20 @@ export const callSyncFunc = <ArgsT extends any[], ReturnT>(
       /* node:coverage enable */
     }
 
-    options?.onStart?.();
+    options.onStart?.();
 
-    result = func(trace, ...args);
+    if (options.deepDisableLam !== undefined) {
+      result = func(trace, ...args);
+    } else {
+      result = func(trace, ...args);
+    }
 
-    options?.onComplete?.(result);
+    options.onComplete?.(result);
 
     return result;
   } catch (e) {
     try {
-      options?.onError?.(e);
+      options.onError?.(e);
     } catch (e2) {
       /* node:coverage ignore next */
       log().error?.(trace, e2);
@@ -87,7 +91,8 @@ export const callSyncFunc = <ArgsT extends any[], ReturnT>(
     /* node:coverage disable */
     if (
       errorCode !== undefined &&
-      (shouldDisableErrorForLoggingAndMetrics(options?.disableLam ?? false, { error, errorCode }) ||
+      (shouldDisableErrorForLoggingAndMetrics(options.disableLam ?? false, { error, errorCode }) ||
+        shouldDisableErrorForLoggingAndMetrics(options.deepDisableLam ?? false, { error, errorCode }) ||
         shouldDisableErrorForLoggingAndMetrics(lamControl.disable, { error, errorCode }))
     ) {
       errorCode = undefined;

--- a/code/cross-platform-packages/freedom-email-sync/src/utils/makeBottomUpTimeOrganizedMailStorageTraverser.ts
+++ b/code/cross-platform-packages/freedom-email-sync/src/utils/makeBottomUpTimeOrganizedMailStorageTraverser.ts
@@ -62,8 +62,11 @@ export const makeBottomUpTimeOrganizedMailStorageTraverser = makeAsyncResultFunc
     const getSameOrPreviousYear = makeAsyncResultFunc(
       [import.meta.filename, 'getSameOrPreviousYear'],
       async (trace, cursorYear: number): PR<TimeOrganizedMailStorageTraverserAccessor | undefined> => {
-        const baseFolderLike = await disableLam(trace, 'not-found', (trace) =>
-          getSyncableAtPath(trace, syncableStore, timeOrganizedPaths.value, syncableItemTypes.exclude('file'))
+        const baseFolderLike = await disableLam('not-found', getSyncableAtPath)(
+          trace,
+          syncableStore,
+          timeOrganizedPaths.value,
+          syncableItemTypes.exclude('file')
         );
         if (!baseFolderLike.ok) {
           if (baseFolderLike.value.errorCode === 'not-found') {
@@ -118,7 +121,7 @@ export const makeBottomUpTimeOrganizedMailStorageTraverser = makeAsyncResultFunc
         const baseYearPath = timeOrganizedPaths.year(makeDate(cursorYear, 1, 1, 0));
         const yearPath = baseYearPath.value;
 
-        const yearBundle = await disableLam(trace, 'not-found', (trace) => getSyncableAtPath(trace, syncableStore, yearPath, 'bundle'));
+        const yearBundle = await disableLam('not-found', getSyncableAtPath)(trace, syncableStore, yearPath, 'bundle');
         if (!yearBundle.ok) {
           if (yearBundle.value.errorCode === 'not-found') {
             return makeSuccess(undefined);
@@ -184,7 +187,7 @@ export const makeBottomUpTimeOrganizedMailStorageTraverser = makeAsyncResultFunc
         const baseYearPath = timeOrganizedPaths.year(makeDate(cursorYear, cursorMonth, 1, 0));
         const monthPath = baseYearPath.month.value;
 
-        const monthBundle = await disableLam(trace, 'not-found', (trace) => getSyncableAtPath(trace, syncableStore, monthPath, 'bundle'));
+        const monthBundle = await disableLam('not-found', getSyncableAtPath)(trace, syncableStore, monthPath, 'bundle');
         if (!monthBundle.ok) {
           if (monthBundle.value.errorCode === 'not-found') {
             return makeSuccess(undefined);
@@ -252,7 +255,7 @@ export const makeBottomUpTimeOrganizedMailStorageTraverser = makeAsyncResultFunc
         const baseYearPath = timeOrganizedPaths.year(makeDate(cursorYear, cursorMonth, cursorDay, 0));
         const dayPath = baseYearPath.month.day.value;
 
-        const dayBundle = await disableLam(trace, 'not-found', (trace) => getSyncableAtPath(trace, syncableStore, dayPath, 'bundle'));
+        const dayBundle = await disableLam('not-found', getSyncableAtPath)(trace, syncableStore, dayPath, 'bundle');
         if (!dayBundle.ok) {
           if (dayBundle.value.errorCode === 'not-found') {
             return makeSuccess(undefined);

--- a/code/cross-platform-packages/freedom-get-or-create/src/utils/getOrCreate.ts
+++ b/code/cross-platform-packages/freedom-get-or-create/src/utils/getOrCreate.ts
@@ -10,7 +10,7 @@ export const getOrCreate = makeAsyncResultFunc(
     trace: Trace,
     { get, create }: { get: PRFunc<T, ErrorCodeT | 'not-found'>; create: PRFunc<T | undefined, ErrorCodeT | 'conflict'> }
   ): PR<T, Exclude<ErrorCodeT, 'conflict' | 'not-found'>> => {
-    const found = await disableLam(trace, 'not-found', (trace) => get(trace));
+    const found = await disableLam('not-found', get)(trace);
     if (found.ok) {
       return found;
     } /* node:coverage disable */ else if (found.value.errorCode !== 'not-found') {
@@ -18,7 +18,7 @@ export const getOrCreate = makeAsyncResultFunc(
     }
     /* node:coverage enable */
 
-    const created = await disableLam(trace, 'conflict', (trace) => create(trace));
+    const created = await disableLam('conflict', create)(trace);
     /* node:coverage disable */
     if (!created.ok) {
       // Try to get the bundle again if there's a conflict, since it might have just been created

--- a/code/cross-platform-packages/freedom-in-memory-syncable-store-backing/src/types/InMemorySyncableStoreBacking.ts
+++ b/code/cross-platform-packages/freedom-in-memory-syncable-store-backing/src/types/InMemorySyncableStoreBacking.ts
@@ -42,7 +42,7 @@ export class InMemorySyncableStoreBacking implements SyncableStoreBacking {
   public readonly existsAtPath = makeAsyncResultFunc(
     [import.meta.filename, 'existsAtPath'],
     async (trace, path: SyncablePath): PR<boolean> => {
-      const found = disableLam(trace, 'not-found', (trace) => traversePath(trace, this.root_, path));
+      const found = disableLam('not-found', traversePath)(trace, this.root_, path);
       if (!found.ok) {
         if (found.value.errorCode === 'not-found') {
           return makeSuccess(false);

--- a/code/cross-platform-packages/freedom-object-store-types/src/utils/forceSetObjectValue.ts
+++ b/code/cross-platform-packages/freedom-object-store-types/src/utils/forceSetObjectValue.ts
@@ -19,13 +19,11 @@ export const forceSetObjectValue = makeAsyncResultFunc(
     { getMutable, update, create, maxAttempts }: ForceSetObjectValueArgs<T, ErrorCodeT>,
     newValue: T
   ): PR<undefined, Exclude<ErrorCodeT, 'conflict' | 'not-found' | 'out-of-date'>> => {
-    const result = await disableLam(trace, 'not-found', (trace) =>
-      forceReplaceObjectValue(trace, { getMutable, update, maxAttempts }, newValue)
-    );
+    const result = await disableLam('not-found', forceReplaceObjectValue)(trace, { getMutable, update, maxAttempts }, newValue);
     if (!result.ok) {
       if (result.value.errorCode === 'not-found') {
         // If the object doesn't exist, try to create it
-        const created = await disableLam(trace, 'conflict', (trace) => create(trace, newValue));
+        const created = await disableLam('conflict', create)(trace, newValue);
         if (!created.ok) {
           if (created.value.errorCode === 'conflict') {
             // If there's a conflict, it was likely just created, so try to get it again

--- a/code/cross-platform-packages/freedom-object-store-types/src/utils/getMutableObjectOrCreate.ts
+++ b/code/cross-platform-packages/freedom-object-store-types/src/utils/getMutableObjectOrCreate.ts
@@ -18,7 +18,7 @@ export const getMutableObjectOrCreate = makeAsyncResultFunc(
       create: PRFunc<T | undefined, ErrorCodeT | 'conflict'>;
     }
   ): PR<StorableObject<T>, Exclude<ErrorCodeT, 'conflict' | 'not-found'>> => {
-    const found = await disableLam(trace, 'not-found', (trace) => getMutable(trace));
+    const found = await disableLam('not-found', getMutable)(trace);
     if (found.ok) {
       return found;
     } /* node:coverage disable */ else if (found.value.errorCode !== 'not-found') {
@@ -26,7 +26,7 @@ export const getMutableObjectOrCreate = makeAsyncResultFunc(
     }
     /* node:coverage enable */
 
-    const created = await disableLam(trace, 'conflict', (trace) => create(trace));
+    const created = await disableLam('conflict', create)(trace);
     /* node:coverage disable */
     if (!created.ok) {
       // Try to get the bundle again if there's a conflict, since it might have just been created

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/attachSyncServiceToSyncableStore.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/attachSyncServiceToSyncableStore.ts
@@ -43,7 +43,7 @@ export const attachSyncServiceToSyncableStore = makeAsyncResultFunc(
       async (trace, { remoteId, path, hash: remoteHash }: { remoteId: RemoteId; path: SyncablePath; hash: Sha256Hash }): PR<undefined> => {
         DEV: syncService.devLogging.appendLogEntry?.({ type: 'notified', pathString: path.toString() });
 
-        const localHash = await disableLam(trace, 'not-found', (trace) => getSyncableHashAtPath(trace, store, path));
+        const localHash = await disableLam('not-found', getSyncableHashAtPath)(trace, store, path);
         if (!localHash.ok) {
           // 'not-found' errors are expected in cases where the remote has content that the local doesn't know about yet
           if (localHash.value.errorCode !== 'not-found') {

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pullSyncableFromRemote.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pullSyncableFromRemote.ts
@@ -77,7 +77,7 @@ export const pullSyncableFromRemote = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 // Helpers

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pullSyncableFromRemotes.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pullSyncableFromRemotes.ts
@@ -4,7 +4,6 @@ import { Cast, objectKeys } from 'freedom-cast';
 import { InternalStateError } from 'freedom-common-errors';
 import type { RemoteId, SyncablePath } from 'freedom-sync-types';
 import type { MutableSyncableStore } from 'freedom-syncable-store-types';
-import { disableLam } from 'freedom-trace-logging-and-metrics';
 
 import type { SyncService } from '../../types/SyncService.ts';
 import { pullSyncableFromRemote } from './pullSyncableFromRemote.ts';
@@ -34,9 +33,7 @@ export const pullSyncableFromRemotes = makeAsyncResultFunc(
         skipErrorCodes: ['generic', 'not-found']
       },
       async (trace, remoteId): PR<'ok', 'not-found'> => {
-        const pulled = await disableLam(trace, 'not-found', (trace) =>
-          pullSyncableFromRemote(trace, { store, syncService }, { path, remoteId })
-        );
+        const pulled = await pullSyncableFromRemote(trace, { store, syncService }, { path, remoteId });
         if (!pulled.ok) {
           if (pulled.value.errorCode === 'not-found') {
             lastNotFoundError = pulled.value;
@@ -67,5 +64,5 @@ export const pullSyncableFromRemotes = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pushSyncableToRemote.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pushSyncableToRemote.ts
@@ -12,7 +12,6 @@ import {
   getSyncableItemTypeAtPathForSync
 } from 'freedom-syncable-store';
 import { ACCESS_CONTROL_BUNDLE_ID, type SyncableStore } from 'freedom-syncable-store-types';
-import { disableLam } from 'freedom-trace-logging-and-metrics';
 
 import type { SyncService } from '../../types/SyncService.ts';
 
@@ -31,9 +30,12 @@ export const pushSyncableToRemote = makeAsyncResultFunc(
     const hash = await getSyncableHashAtPath(trace, store, path);
 
     // Not logging this pull since we're really just using this as a status check
-    const pulled = await disableLam(trace, 'not-found', (trace) =>
-      pullFromRemote(trace, { path, hash: hash.ok ? hash.value : undefined, sendData: false, strategy: 'default' })
-    );
+    const pulled = await pullFromRemote(trace, {
+      path,
+      hash: hash.ok ? hash.value : undefined,
+      sendData: false,
+      strategy: 'default'
+    });
     if (!pulled.ok) {
       if (pulled.value.errorCode === 'not-found') {
         DEV: debugTopic('SYNC', (log) => log(`Pulled ${path.toString()}: nothing found on remote.  Will try to push everything`));
@@ -49,7 +51,7 @@ export const pushSyncableToRemote = makeAsyncResultFunc(
     DEV: debugTopic('SYNC', (log) => log(`Pulled ${path.toString()}: local and remote are out of sync.  Will try to push missing content`));
     return await pushMissingSyncableContentToRemote(trace, { store, syncService, pulled: pulled.value }, { remoteId, path });
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 export const pushMissingSyncableContentToRemote = makeAsyncResultFunc(
@@ -78,7 +80,7 @@ export const pushMissingSyncableContentToRemote = makeAsyncResultFunc(
         return await pushBundle(trace, { remoteId, store, syncService, path, pulledHashesById: pulled.hashesById });
     }
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 // Helpers
@@ -107,7 +109,7 @@ const pushEverything = makeAsyncResultFunc(
       }
     }
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 const pushBundle = makeAsyncResultFunc(
@@ -164,7 +166,7 @@ const pushBundle = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 const pushFolder = makeAsyncResultFunc(
@@ -233,7 +235,7 @@ const pushFolder = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );
 
 const pushFile = makeAsyncResultFunc(
@@ -260,5 +262,5 @@ const pushFile = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pushSyncableToRemotes.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/internal/utils/pushSyncableToRemotes.ts
@@ -4,7 +4,6 @@ import { Cast, objectKeys } from 'freedom-cast';
 import { generalizeFailureResult, InternalStateError } from 'freedom-common-errors';
 import type { RemoteId, SyncablePath } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
-import { disableLam } from 'freedom-trace-logging-and-metrics';
 
 import type { SyncService } from '../../types/SyncService.ts';
 import { pushSyncableToRemote } from './pushSyncableToRemote.ts';
@@ -41,9 +40,7 @@ export const pushSyncableToRemotes = makeAsyncResultFunc(
         skipErrorCodes: ['generic', 'not-found']
       },
       async (trace, remoteId): PR<'ok', 'not-found'> => {
-        const pushed = await disableLam(trace, 'not-found', (trace) =>
-          pushSyncableToRemote(trace, { store, syncService }, { remoteId, path })
-        );
+        const pushed = await pushSyncableToRemote(trace, { store, syncService }, { remoteId, path });
         if (!pushed.ok) {
           if (pushed.value.errorCode === 'not-found') {
             lastNotFoundError = pushed.value;
@@ -70,5 +67,5 @@ export const pushSyncableToRemotes = makeAsyncResultFunc(
 
     return makeSuccess(undefined);
   },
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-sync-service/src/utils/makeSyncService.ts
+++ b/code/cross-platform-packages/freedom-sync-service/src/utils/makeSyncService.ts
@@ -32,7 +32,7 @@ export const makeSyncService = makeAsyncResultFunc(
     { store, remoteConnections, shouldSyncWithAllRemotes, getSyncStrategyForPath, shouldRecordLogs = false }: MakeSyncServiceArgs
   ): PR<SyncService> => {
     const pullQueue = new TaskQueue(trace);
-    const pushQueue = disableLam(trace, 'not-found', (trace) => new TaskQueue(trace));
+    const pushQueue = disableLam('not-found', (trace) => new TaskQueue(trace))(trace);
 
     let detachSyncService: () => void = noop;
 
@@ -60,9 +60,7 @@ export const makeSyncService = makeAsyncResultFunc(
         const version = JSON.stringify({ remoteId, hash });
 
         pullQueue.add({ key, version }, async (trace) => {
-          const pulled = await disableLam(trace, 'not-found', (trace) =>
-            pullSyncableFromRemotes(trace, { store, syncService: service }, { remoteId, path })
-          );
+          const pulled = await disableLam('not-found', pullSyncableFromRemotes)(trace, { store, syncService: service }, { remoteId, path });
           if (!pulled.ok) {
             if (pulled.value.errorCode === 'not-found') {
               return makeSuccess(undefined);

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/context/isSyncableValidationEnabled.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/context/isSyncableValidationEnabled.ts
@@ -7,3 +7,8 @@ export const useIsSyncableValidationEnabled = (trace: Trace) => useTraceContext(
 
 export const isSyncableValidationEnabledProvider = <ReturnT>(trace: Trace, enabled: boolean, callback: (trace: Trace) => ReturnT) =>
   IsSyncableValidationEnabledContext.provider(trace, { enabled }, callback);
+
+export const disableSyncableValidation =
+  <ArgsT extends any[], ReturnT>(callback: (trace: Trace, ...args: ArgsT) => ReturnT) =>
+  (trace: Trace, ...args: ArgsT) =>
+    isSyncableValidationEnabledProvider(trace, false, (trace) => callback(trace, ...args));

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/utils/sync/createViaSyncFolderAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/utils/sync/createViaSyncFolderAtPath.ts
@@ -5,32 +5,35 @@ import type { SyncableItemMetadata, SyncablePath } from 'freedom-sync-types';
 import type { MutableSyncableFolderAccessor, MutableSyncableStore } from 'freedom-syncable-store-types';
 
 import { getMutableParentSyncable } from '../../../utils/get/getMutableParentSyncable.ts';
-import { isSyncableValidationEnabledProvider } from '../../context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../context/isSyncableValidationEnabled.ts';
 
+// TODO: reenable validation in a smarter way
 export const createViaSyncFolderAtPath = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: MutableSyncableStore, path: SyncablePath, metadata: SyncableItemMetadata) =>
-    await isSyncableValidationEnabledProvider(
+  disableSyncableValidation(
+    async (
       trace,
-      false,
-      async (trace): PR<MutableSyncableFolderAccessor, 'conflict' | 'not-found' | 'untrusted' | 'wrong-type'> => {
-        if (path.ids.length === 0) {
-          // Root will always already exist
-          return makeFailure(new ConflictError(trace, { errorCode: 'conflict' }));
-        }
-
-        const parent = await getMutableParentSyncable(trace, store, path, 'folder');
-        if (!parent.ok) {
-          return parent;
-        }
-
-        const created = await parent.value.createFolder(trace, { mode: 'via-sync', id: path.lastId!, metadata });
-        if (!created.ok) {
-          // 'deleted' should never happen here because createFolder with 'via-sync' doesn't check for deletion
-          return generalizeFailureResult(trace, created, 'deleted');
-        }
-
-        return makeSuccess(created.value);
+      store: MutableSyncableStore,
+      path: SyncablePath,
+      metadata: SyncableItemMetadata
+    ): PR<MutableSyncableFolderAccessor, 'conflict' | 'not-found' | 'untrusted' | 'wrong-type'> => {
+      if (path.ids.length === 0) {
+        // Root will always already exist
+        return makeFailure(new ConflictError(trace, { errorCode: 'conflict' }));
       }
-    )
+
+      const parent = await getMutableParentSyncable(trace, store, path, 'folder');
+      if (!parent.ok) {
+        return parent;
+      }
+
+      const created = await parent.value.createFolder(trace, { mode: 'via-sync', id: path.lastId!, metadata });
+      if (!created.ok) {
+        // 'deleted' should never happen here because createFolder with 'via-sync' doesn't check for deletion
+        return generalizeFailureResult(trace, created, 'deleted');
+      }
+
+      return makeSuccess(created.value);
+    }
+  )
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/utils/sync/createViaSyncPreEncodedBinaryFileAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/utils/sync/createViaSyncPreEncodedBinaryFileAtPath.ts
@@ -9,34 +9,38 @@ import { ACCESS_CONTROL_BUNDLE_ID } from 'freedom-syncable-store-types';
 import { lastIndexOf } from 'lodash-es';
 
 import { getMutableParentSyncable } from '../../../utils/get/getMutableParentSyncable.ts';
-import { isSyncableValidationEnabledProvider } from '../../context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../context/isSyncableValidationEnabled.ts';
 
+// TODO: reenable validation in a smarter way
 export const createViaSyncPreEncodedBinaryFileAtPath = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace: Trace, store: MutableSyncableStore, path: SyncablePath, encodedValue: Uint8Array, metadata: SyncableItemMetadata) =>
-    await isSyncableValidationEnabledProvider(
-      trace,
-      false,
-      async (trace): PR<MutableSyncableFileAccessor, 'conflict' | 'not-found' | 'untrusted' | 'wrong-type'> => {
-        // Any time any part of an access control bundle is changed, clear trust for the associated folder
-        const accessControlBundleIdIndex = lastIndexOf(path.ids, ACCESS_CONTROL_BUNDLE_ID);
-        if (accessControlBundleIdIndex >= 0) {
-          const folderPath = new SyncablePath(path.storageRootId, ...path.ids.slice(0, accessControlBundleIdIndex));
-          store.localTrustMarks.clearTrust(folderPath);
-        }
-
-        const parent = await getMutableParentSyncable(trace, store, path, syncableItemTypes.exclude('file'));
-        if (!parent.ok) {
-          return parent;
-        }
-
-        const created = await parent.value.createBinaryFile(trace, { mode: 'via-sync', id: path.lastId!, encodedValue, metadata });
-        if (!created.ok) {
-          // 'deleted' should never happen here because createBinaryFile with 'via-sync' doesn't check for deletion
-          return generalizeFailureResult(trace, created, 'deleted');
-        }
-
-        return makeSuccess(created.value);
+  disableSyncableValidation(
+    async (
+      trace: Trace,
+      store: MutableSyncableStore,
+      path: SyncablePath,
+      encodedValue: Uint8Array,
+      metadata: SyncableItemMetadata
+    ): PR<MutableSyncableFileAccessor, 'conflict' | 'not-found' | 'untrusted' | 'wrong-type'> => {
+      // Any time any part of an access control bundle is changed, clear trust for the associated folder
+      const accessControlBundleIdIndex = lastIndexOf(path.ids, ACCESS_CONTROL_BUNDLE_ID);
+      if (accessControlBundleIdIndex >= 0) {
+        const folderPath = new SyncablePath(path.storageRootId, ...path.ids.slice(0, accessControlBundleIdIndex));
+        store.localTrustMarks.clearTrust(folderPath);
       }
-    )
+
+      const parent = await getMutableParentSyncable(trace, store, path, syncableItemTypes.exclude('file'));
+      if (!parent.ok) {
+        return parent;
+      }
+
+      const created = await parent.value.createBinaryFile(trace, { mode: 'via-sync', id: path.lastId!, encodedValue, metadata });
+      if (!created.ok) {
+        // 'deleted' should never happen here because createBinaryFile with 'via-sync' doesn't check for deletion
+        return generalizeFailureResult(trace, created, 'deleted');
+      }
+
+      return makeSuccess(created.value);
+    }
+  )
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createBinaryFileAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createBinaryFileAtPath.ts
@@ -5,7 +5,7 @@ import type { DynamicSyncableItemName, SyncableOriginOptions, SyncablePath } fro
 import { syncableItemTypes } from 'freedom-sync-types';
 import type { MutableSyncableFileAccessor, MutableSyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getMutableSyncableAtPath } from '../get/getMutableSyncableAtPath.ts';
 
 export const createBinaryFileAtPath = makeAsyncResultFunc(
@@ -18,10 +18,11 @@ export const createBinaryFileAtPath = makeAsyncResultFunc(
   ): PR<MutableSyncableFileAccessor, 'conflict' | 'deleted' | 'not-found' | 'untrusted' | 'wrong-type'> => {
     // Disabling validation since we're creating something new -- and this might be a new access control bundle for example, which would
     // make checking it impossible anyway
-    const parent = await isSyncableValidationEnabledProvider(
+    const parent = await disableSyncableValidation(getMutableSyncableAtPath)(
       trace,
-      false,
-      async (trace) => await getMutableSyncableAtPath(trace, store, path.parentPath!, syncableItemTypes.exclude('file'))
+      store,
+      path.parentPath!,
+      syncableItemTypes.exclude('file')
     );
     if (!parent.ok) {
       return parent;

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createBundleAtPath.ts
@@ -4,7 +4,7 @@ import type { DynamicSyncableItemName, SyncableOriginOptions, SyncablePath } fro
 import { syncableItemTypes } from 'freedom-sync-types';
 import type { MutableSyncableBundleAccessor, MutableSyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getMutableSyncableAtPath } from '../get/getMutableSyncableAtPath.ts';
 
 export const createBundleAtPath = makeAsyncResultFunc(
@@ -17,10 +17,11 @@ export const createBundleAtPath = makeAsyncResultFunc(
   ): PR<MutableSyncableBundleAccessor, 'conflict' | 'deleted' | 'not-found' | 'untrusted' | 'wrong-type'> => {
     // Disabling validation since we're creating something new -- and this might be a new access control bundle for example, which would
     // make checking it impossible anyway
-    const parent = await isSyncableValidationEnabledProvider(
+    const parent = await disableSyncableValidation(getMutableSyncableAtPath)(
       trace,
-      false,
-      async (trace) => await getMutableSyncableAtPath(trace, store, path.parentPath!, syncableItemTypes.exclude('file'))
+      store,
+      path.parentPath!,
+      syncableItemTypes.exclude('file')
     );
     if (!parent.ok) {
       return parent;

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createFolderAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/create/createFolderAtPath.ts
@@ -3,7 +3,7 @@ import { makeAsyncResultFunc } from 'freedom-async';
 import type { DynamicSyncableItemName, SyncableOriginOptions, SyncablePath } from 'freedom-sync-types';
 import type { MutableSyncableFolderAccessor, MutableSyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getMutableSyncableAtPath } from '../get/getMutableSyncableAtPath.ts';
 
 export const createFolderAtPath = makeAsyncResultFunc(
@@ -16,11 +16,7 @@ export const createFolderAtPath = makeAsyncResultFunc(
   ): PR<MutableSyncableFolderAccessor, 'conflict' | 'deleted' | 'not-found' | 'untrusted' | 'wrong-type'> => {
     // Disabling validation since we're creating something new -- and this might be a new access control bundle for example, which would
     // make checking it impossible anyway
-    const parent = await isSyncableValidationEnabledProvider(
-      trace,
-      false,
-      async (trace) => await getMutableSyncableAtPath(trace, store, path.parentPath!, 'folder')
-    );
+    const parent = await disableSyncableValidation(getMutableSyncableAtPath)(trace, store, path.parentPath!, 'folder');
     if (!parent.ok) {
       return parent;
     }

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/get-or-create/getOrCreateBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/get-or-create/getOrCreateBundleAtPath.ts
@@ -4,24 +4,21 @@ import { getOrCreate } from 'freedom-get-or-create';
 import type { SyncablePath } from 'freedom-sync-types';
 import type { MutableFileStore, MutableSyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { createBundleAtPath } from '../create/createBundleAtPath.ts';
 import { getMutableSyncableAtPath } from '../get/getMutableSyncableAtPath.ts';
 
 export const getOrCreateBundleAtPath = makeAsyncResultFunc(
   [import.meta.filename],
-  async (
-    trace,
-    store: MutableSyncableStore,
-    path: SyncablePath
-  ): PR<MutableFileStore, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> =>
-    await isSyncableValidationEnabledProvider(
+  disableSyncableValidation(
+    async (
       trace,
-      false,
-      async (trace) =>
-        await getOrCreate(trace, {
-          get: (trace) => getMutableSyncableAtPath(trace, store, path, 'bundle'),
-          create: (trace) => createBundleAtPath(trace, store, path)
-        })
-    )
+      store: MutableSyncableStore,
+      path: SyncablePath
+    ): PR<MutableFileStore, 'deleted' | 'format-error' | 'not-found' | 'untrusted' | 'wrong-type'> =>
+      await getOrCreate(trace, {
+        get: (trace) => getMutableSyncableAtPath(trace, store, path, 'bundle'),
+        create: (trace) => createBundleAtPath(trace, store, path)
+      })
+  )
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/get/getConflictFreeDocumentFromBundleAtPath.ts
@@ -24,7 +24,7 @@ import { noop } from 'lodash-es';
 
 import { APPLY_DELTAS_LIMIT_TIME_MSEC, CACHE_DURATION_MSEC } from '../../internal/consts/timing.ts';
 import { accessControlDocumentProvider } from '../../internal/context/accessControlDocument.ts';
-import { isSyncableValidationEnabledProvider, useIsSyncableValidationEnabled } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation, useIsSyncableValidationEnabled } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { SyncableStoreAccessControlDocument } from '../../types/SyncableStoreAccessControlDocument.ts';
 import { getRoleForOrigin } from '../validation/getRoleForOrigin.ts';
 import { getBundleAtPath } from './getBundleAtPath.ts';
@@ -304,9 +304,9 @@ export const getConflictFreeDocumentFromBundleAtPath = makeAsyncResultFunc(
                 deltaPaths,
                 {},
                 async (trace, deltaPath): PR<undefined, 'not-found' | 'untrusted' | 'wrong-type' | 'format-error'> => {
-                  const encodedDelta = await isSyncableValidationEnabledProvider(trace, false, (trace) =>
-                    getStringFromFile(trace, store, deltaPath, { checkForDeletion: false })
-                  );
+                  const encodedDelta = await disableSyncableValidation(getStringFromFile)(trace, store, deltaPath, {
+                    checkForDeletion: false
+                  });
                   if (!encodedDelta.ok) {
                     return generalizeFailureResult(trace, encodedDelta, 'deleted');
                   }

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/markSyncableNeedsRecomputeHashAtPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/markSyncableNeedsRecomputeHashAtPath.ts
@@ -3,7 +3,7 @@ import { makeAsyncResultFunc } from 'freedom-async';
 import type { SyncablePath } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncableAtPath } from './get/getSyncableAtPath.ts';
 
 export const markSyncableNeedsRecomputeHashAtPath = makeAsyncResultFunc(
@@ -11,11 +11,7 @@ export const markSyncableNeedsRecomputeHashAtPath = makeAsyncResultFunc(
   async (trace, store: SyncableStore, path: SyncablePath): PR<undefined, 'not-found' | 'untrusted' | 'wrong-type'> => {
     // Disabling validation since we're creating something new -- and this might be a new access control bundle for example, which would
     // make checking it impossible anyway
-    const itemAccessor = await isSyncableValidationEnabledProvider(
-      trace,
-      false,
-      async (trace) => await getSyncableAtPath(trace, store, path)
-    );
+    const itemAccessor = await disableSyncableValidation(getSyncableAtPath)(trace, store, path);
     if (!itemAccessor.ok) {
       return itemAccessor;
     }

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullBundle.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullBundle.ts
@@ -6,73 +6,77 @@ import type { Trace } from 'freedom-contexts';
 import type { InSyncBundle, OutOfSyncBundle, SyncableId, SyncablePath, SyncBatchContents, SyncStrategy } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncBatchContentsForPath } from '../../internal/utils/getSyncBatchContentsForPath.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const pullBundle = makeAsyncResultFunc(
   [import.meta.filename],
-  async (
-    trace: Trace,
-    store: SyncableStore,
-    { hash: downstreamHash, path, strategy }: { path: SyncablePath; hash?: Sha256Hash; strategy: SyncStrategy }
-  ): PR<InSyncBundle | OutOfSyncBundle, 'not-found'> => {
-    const bundle = await getSyncableAtPath(trace, store, path, 'bundle');
-    if (!bundle.ok) {
-      return generalizeFailureResult(trace, bundle, ['untrusted', 'wrong-type']);
-    }
+  disableSyncableValidation(
+    async (
+      trace: Trace,
+      store: SyncableStore,
+      { hash: downstreamHash, path, strategy }: { path: SyncablePath; hash?: Sha256Hash; strategy: SyncStrategy }
+    ): PR<InSyncBundle | OutOfSyncBundle, 'not-found'> => {
+      const bundle = await getSyncableAtPath(trace, store, path, 'bundle');
+      if (!bundle.ok) {
+        return generalizeFailureResult(trace, bundle, ['untrusted', 'wrong-type']);
+      }
 
-    const hash = await bundle.value.getHash(trace);
-    if (!hash.ok) {
-      return hash;
-    }
+      const hash = await bundle.value.getHash(trace);
+      if (!hash.ok) {
+        return hash;
+      }
 
-    if (hash.value === downstreamHash) {
-      return makeSuccess({ type: 'bundle', outOfSync: false } satisfies InSyncBundle);
-    }
+      if (hash.value === downstreamHash) {
+        return makeSuccess({ type: 'bundle', outOfSync: false } satisfies InSyncBundle);
+      }
 
-    const metadata = await bundle.value.getMetadata(trace);
-    if (!metadata.ok) {
-      return metadata;
-    }
+      const metadata = await bundle.value.getMetadata(trace);
+      if (!metadata.ok) {
+        return metadata;
+      }
 
-    const metadataById = await bundle.value.getMetadataById(trace);
-    if (!metadataById.ok) {
-      return metadataById;
-    }
+      const metadataById = await bundle.value.getMetadataById(trace);
+      if (!metadataById.ok) {
+        return metadataById;
+      }
 
-    const hashesById = objectEntries(metadataById.value).reduce(
-      (out, [id, metadata]) => {
-        if (metadata === undefined) {
+      const hashesById = objectEntries(metadataById.value).reduce(
+        (out, [id, metadata]) => {
+          if (metadata === undefined) {
+            return out;
+          }
+
+          out[id] = metadata.hash;
+
           return out;
-        }
+        },
+        {} as Partial<Record<SyncableId, Sha256Hash>>
+      );
 
-        out[id] = metadata.hash;
-
-        return out;
-      },
-      {} as Partial<Record<SyncableId, Sha256Hash>>
-    );
-
-    let batchContents: SyncBatchContents | undefined;
-    switch (strategy) {
-      case 'default':
-        break; // Nothing special to do
-      case 'batch': {
-        // Loading batches is always best effort
-        const loaded = await getSyncBatchContentsForPath(trace, store, path);
-        if (loaded.ok) {
-          batchContents = loaded.value;
+      let batchContents: SyncBatchContents | undefined;
+      switch (strategy) {
+        case 'default':
+          break; // Nothing special to do
+        case 'batch': {
+          // Loading batches is always best effort
+          const loaded = await getSyncBatchContentsForPath(trace, store, path);
+          if (loaded.ok) {
+            batchContents = loaded.value;
+          }
         }
       }
-    }
 
-    return makeSuccess({
-      type: 'bundle',
-      outOfSync: true,
-      hashesById,
-      metadata: metadata.value,
-      batchContents
-    } satisfies OutOfSyncBundle);
-  },
-  { disableLam: 'not-found' }
+      return makeSuccess({
+        type: 'bundle',
+        outOfSync: true,
+        hashesById,
+        metadata: metadata.value,
+        batchContents
+      } satisfies OutOfSyncBundle);
+    }
+  ),
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullFile.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullFile.ts
@@ -6,51 +6,59 @@ import type { Trace } from 'freedom-contexts';
 import type { InSyncFile, OutOfSyncFile, SyncablePath, SyncStrategy } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const pullFile = makeAsyncResultFunc(
   [import.meta.filename],
-  async (
-    trace: Trace,
-    store: SyncableStore,
-    { hash: downstreamHash, path, sendData = false }: { path: SyncablePath; hash?: Sha256Hash; sendData?: boolean; strategy: SyncStrategy }
-  ): PR<InSyncFile | OutOfSyncFile, 'not-found'> => {
-    const file = await getSyncableAtPath(trace, store, path, 'file');
-    if (!file.ok) {
-      return generalizeFailureResult(trace, file, ['untrusted', 'wrong-type']);
-    }
-
-    const hash = await file.value.getHash(trace);
-    if (!hash.ok) {
-      return hash;
-    }
-
-    if (hash.value === downstreamHash) {
-      return makeSuccess({ type: 'file', outOfSync: false } satisfies InSyncFile);
-    }
-
-    // TODO: changing provenance (by accepting or rejecting) should probably trigger a hash change or something
-
-    const metadata = await file.value.getMetadata(trace);
-    if (!metadata.ok) {
-      return metadata;
-    }
-
-    if (!sendData) {
-      return makeSuccess({ type: 'file', outOfSync: true, metadata: metadata.value } satisfies OutOfSyncFile);
-    } else {
-      const data = await file.value.getEncodedBinary(trace);
-      if (!data.ok) {
-        return data;
+  disableSyncableValidation(
+    async (
+      trace: Trace,
+      store: SyncableStore,
+      {
+        hash: downstreamHash,
+        path,
+        sendData = false
+      }: { path: SyncablePath; hash?: Sha256Hash; sendData?: boolean; strategy: SyncStrategy }
+    ): PR<InSyncFile | OutOfSyncFile, 'not-found'> => {
+      const file = await getSyncableAtPath(trace, store, path, 'file');
+      if (!file.ok) {
+        return generalizeFailureResult(trace, file, ['untrusted', 'wrong-type']);
       }
 
-      return makeSuccess({
-        type: 'file',
-        outOfSync: true,
-        data: data.value,
-        metadata: metadata.value
-      } satisfies OutOfSyncFile);
+      const hash = await file.value.getHash(trace);
+      if (!hash.ok) {
+        return hash;
+      }
+
+      if (hash.value === downstreamHash) {
+        return makeSuccess({ type: 'file', outOfSync: false } satisfies InSyncFile);
+      }
+
+      // TODO: changing provenance (by accepting or rejecting) should probably trigger a hash change or something
+
+      const metadata = await file.value.getMetadata(trace);
+      if (!metadata.ok) {
+        return metadata;
+      }
+
+      if (!sendData) {
+        return makeSuccess({ type: 'file', outOfSync: true, metadata: metadata.value } satisfies OutOfSyncFile);
+      } else {
+        const data = await file.value.getEncodedBinary(trace);
+        if (!data.ok) {
+          return data;
+        }
+
+        return makeSuccess({
+          type: 'file',
+          outOfSync: true,
+          data: data.value,
+          metadata: metadata.value
+        } satisfies OutOfSyncFile);
+      }
     }
-  },
-  { disableLam: 'not-found' }
+  ),
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullFolder.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullFolder.ts
@@ -6,73 +6,77 @@ import type { Trace } from 'freedom-contexts';
 import type { InSyncFolder, OutOfSyncFolder, SyncableId, SyncablePath, SyncBatchContents, SyncStrategy } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncBatchContentsForPath } from '../../internal/utils/getSyncBatchContentsForPath.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const pullFolder = makeAsyncResultFunc(
   [import.meta.filename],
-  async (
-    trace: Trace,
-    store: SyncableStore,
-    { hash: downstreamHash, path, strategy }: { path: SyncablePath; hash?: Sha256Hash; strategy: SyncStrategy }
-  ): PR<InSyncFolder | OutOfSyncFolder, 'not-found'> => {
-    const folder = await getSyncableAtPath(trace, store, path, 'folder');
-    if (!folder.ok) {
-      return generalizeFailureResult(trace, folder, ['untrusted', 'wrong-type']);
-    }
+  disableSyncableValidation(
+    async (
+      trace: Trace,
+      store: SyncableStore,
+      { hash: downstreamHash, path, strategy }: { path: SyncablePath; hash?: Sha256Hash; strategy: SyncStrategy }
+    ): PR<InSyncFolder | OutOfSyncFolder, 'not-found'> => {
+      const folder = await getSyncableAtPath(trace, store, path, 'folder');
+      if (!folder.ok) {
+        return generalizeFailureResult(trace, folder, ['untrusted', 'wrong-type']);
+      }
 
-    const hash = await folder.value.getHash(trace);
-    if (!hash.ok) {
-      return hash;
-    }
+      const hash = await folder.value.getHash(trace);
+      if (!hash.ok) {
+        return hash;
+      }
 
-    if (hash.value === downstreamHash) {
-      return makeSuccess({ type: 'folder', outOfSync: false } satisfies InSyncFolder);
-    }
+      if (hash.value === downstreamHash) {
+        return makeSuccess({ type: 'folder', outOfSync: false } satisfies InSyncFolder);
+      }
 
-    const metadata = await folder.value.getMetadata(trace);
-    if (!metadata.ok) {
-      return metadata;
-    }
+      const metadata = await folder.value.getMetadata(trace);
+      if (!metadata.ok) {
+        return metadata;
+      }
 
-    const metadataById = await folder.value.getMetadataById(trace);
-    if (!metadataById.ok) {
-      return metadataById;
-    }
+      const metadataById = await folder.value.getMetadataById(trace);
+      if (!metadataById.ok) {
+        return metadataById;
+      }
 
-    const hashesById = objectEntries(metadataById.value).reduce(
-      (out, [id, metadata]) => {
-        if (metadata === undefined) {
+      const hashesById = objectEntries(metadataById.value).reduce(
+        (out, [id, metadata]) => {
+          if (metadata === undefined) {
+            return out;
+          }
+
+          out[id] = metadata.hash;
+
           return out;
-        }
+        },
+        {} as Partial<Record<SyncableId, Sha256Hash>>
+      );
 
-        out[id] = metadata.hash;
-
-        return out;
-      },
-      {} as Partial<Record<SyncableId, Sha256Hash>>
-    );
-
-    let batchContents: SyncBatchContents | undefined;
-    switch (strategy) {
-      case 'default':
-        break; // Nothing special to do
-      case 'batch': {
-        // Loading batches is always best effort
-        const loaded = await getSyncBatchContentsForPath(trace, store, path);
-        if (loaded.ok) {
-          batchContents = loaded.value;
+      let batchContents: SyncBatchContents | undefined;
+      switch (strategy) {
+        case 'default':
+          break; // Nothing special to do
+        case 'batch': {
+          // Loading batches is always best effort
+          const loaded = await getSyncBatchContentsForPath(trace, store, path);
+          if (loaded.ok) {
+            batchContents = loaded.value;
+          }
         }
       }
-    }
 
-    return makeSuccess({
-      type: 'folder',
-      outOfSync: true,
-      hashesById,
-      metadata: metadata.value,
-      batchContents
-    } satisfies OutOfSyncFolder);
-  },
-  { disableLam: 'not-found' }
+      return makeSuccess({
+        type: 'folder',
+        outOfSync: true,
+        hashesById,
+        metadata: metadata.value,
+        batchContents
+      } satisfies OutOfSyncFolder);
+    }
+  ),
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/pull/pullPath.ts
@@ -1,11 +1,9 @@
 import type { PR } from 'freedom-async';
 import { makeAsyncResultFunc } from 'freedom-async';
-import { generalizeFailureResult } from 'freedom-common-errors';
 import type { SyncPullArgs, SyncPullResponse } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
-import { disableLam } from 'freedom-trace-logging-and-metrics';
 
-import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
+import { getSyncableItemTypeAtPathForSync } from '../sync/getSyncableItemTypeAtPathForSync.ts';
 import { pullBundle } from './pullBundle.ts';
 import { pullFile } from './pullFile.ts';
 import { pullFolder } from './pullFolder.ts';
@@ -13,12 +11,12 @@ import { pullFolder } from './pullFolder.ts';
 export const pullPath = makeAsyncResultFunc(
   [import.meta.filename],
   async (trace, store: SyncableStore, args: SyncPullArgs): PR<SyncPullResponse, 'not-found'> => {
-    const syncableItem = await disableLam(trace, 'not-found', (trace) => getSyncableAtPath(trace, store, args.path));
-    if (!syncableItem.ok) {
-      return generalizeFailureResult(trace, syncableItem, ['untrusted', 'wrong-type']);
+    const itemType = await getSyncableItemTypeAtPathForSync(trace, store, args.path);
+    if (!itemType.ok) {
+      return itemType;
     }
 
-    switch (syncableItem.value.type) {
+    switch (itemType.value) {
       case 'folder':
         return await pullFolder(trace, store, args);
 
@@ -30,5 +28,5 @@ export const pullPath = makeAsyncResultFunc(
     }
   },
   // This will commonly be not-found if the service doesn't yet have the data
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/push/internal/pushBatchContents.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/push/internal/pushBatchContents.ts
@@ -24,7 +24,7 @@ export const pushBatchContents = makeAsyncResultFunc(
           }
 
           const newPath = parentPath.append(id);
-          const created = await disableLam(trace, 'conflict', (trace) => createViaSyncFolderAtPath(trace, store, newPath, folder.metadata));
+          const created = await disableLam('conflict', createViaSyncFolderAtPath)(trace, store, newPath, folder.metadata);
           if (!created.ok) {
             return generalizeFailureResult(trace, created, ['untrusted', 'wrong-type'], `Failed to push folder: ${newPath.toString()}`);
           }
@@ -48,7 +48,7 @@ export const pushBatchContents = makeAsyncResultFunc(
           }
 
           const newPath = parentPath.append(id);
-          const created = await disableLam(trace, 'conflict', (trace) => createViaSyncBundleAtPath(trace, store, newPath, bundle.metadata));
+          const created = await disableLam('conflict', createViaSyncBundleAtPath)(trace, store, newPath, bundle.metadata);
           if (!created.ok) {
             return generalizeFailureResult(trace, created, ['untrusted', 'wrong-type'], `Failed to push bundle: ${newPath.toString()}`);
           }
@@ -72,8 +72,12 @@ export const pushBatchContents = makeAsyncResultFunc(
           }
 
           const newPath = parentPath.append(id);
-          const created = await disableLam(trace, 'conflict', (trace) =>
-            createViaSyncPreEncodedBinaryFileAtPath(trace, store, newPath, file.data, file.metadata)
+          const created = await disableLam('conflict', createViaSyncPreEncodedBinaryFileAtPath)(
+            trace,
+            store,
+            newPath,
+            file.data,
+            file.metadata
           );
           if (!created.ok) {
             return generalizeFailureResult(trace, created, ['untrusted', 'wrong-type'], `Failed to push file: ${newPath.toString()}`);

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushBundle.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushBundle.ts
@@ -23,7 +23,7 @@ export const pushBundle = makeAsyncResultFunc(
       batchContents?: SyncBatchContents;
     }
   ): PR<undefined, 'not-found'> => {
-    const bundle = await disableLam(trace, 'conflict', (trace) => createViaSyncBundleAtPath(trace, store, path, metadata));
+    const bundle = await disableLam('conflict', createViaSyncBundleAtPath)(trace, store, path, metadata);
     if (!bundle.ok) {
       // Treating conflicts as ok since this will often be the case when using a batch strategy or when syncing with predicable ids
       if (bundle.value.errorCode !== 'conflict') {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushFile.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushFile.ts
@@ -22,9 +22,7 @@ export const pushFile = makeAsyncResultFunc(
       metadata: SyncableItemMetadata;
     }
   ): PR<undefined, 'not-found'> => {
-    const file = await disableLam(trace, 'conflict', (trace) =>
-      createViaSyncPreEncodedBinaryFileAtPath(trace, store, path, data, metadata)
-    );
+    const file = await disableLam('conflict', createViaSyncPreEncodedBinaryFileAtPath)(trace, store, path, data, metadata);
     if (!file.ok) {
       // Treating conflicts as ok since this will often be the case when syncing with predicable ids
       if (file.value.errorCode !== 'conflict') {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushFolder.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushFolder.ts
@@ -28,7 +28,7 @@ export const pushFolder = makeAsyncResultFunc(
       return makeSuccess(undefined);
     }
 
-    const folder = await disableLam(trace, 'conflict', (trace) => createViaSyncFolderAtPath(trace, store, path, metadata));
+    const folder = await disableLam('conflict', createViaSyncFolderAtPath)(trace, store, path, metadata);
     if (!folder.ok) {
       // Treating conflicts as ok since this will often be the case when using a batch strategy or when syncing with predicable ids
       if (folder.value.errorCode !== 'conflict') {

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushPath.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/push/pushPath.ts
@@ -2,7 +2,6 @@ import type { PR } from 'freedom-async';
 import { makeAsyncResultFunc } from 'freedom-async';
 import type { SyncPushArgs } from 'freedom-sync-types';
 import type { MutableSyncableStore } from 'freedom-syncable-store-types';
-import { disableLam } from 'freedom-trace-logging-and-metrics';
 
 import { pushBundle } from './pushBundle.ts';
 import { pushFile } from './pushFile.ts';
@@ -10,21 +9,20 @@ import { pushFolder } from './pushFolder.ts';
 
 export const pushPath = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: MutableSyncableStore, args: SyncPushArgs): PR<undefined, 'not-found'> =>
-    await disableLam(trace, 'not-found', async (trace) => {
-      switch (args.type) {
-        case 'folder':
-          return await pushFolder(trace, store, args);
+  async (trace, store: MutableSyncableStore, args: SyncPushArgs): PR<undefined, 'not-found'> => {
+    switch (args.type) {
+      case 'folder':
+        return await pushFolder(trace, store, args);
 
-        case 'bundle':
-          return await pushBundle(trace, store, args);
+      case 'bundle':
+        return await pushBundle(trace, store, args);
 
-        case 'file':
-          return await pushFile(trace, store, args);
-      }
-    }),
+      case 'file':
+        return await pushFile(trace, store, args);
+    }
+  },
   // 'not-found' happens during push fairly commonly when doing an initial sync to a server and simultaneously updating the client, because
   // the client will try to push newer content before the base folders have been initially pushed -- but this will automatically get
   // resolved as the initial sync continues
-  { disableLam: 'not-found' }
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getBundleAtPathForSync.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getBundleAtPathForSync.ts
@@ -5,50 +5,51 @@ import type { SyncableId, SyncableItemMetadata, SyncablePath, SyncBatchContents,
 import type { LocalItemMetadata } from 'freedom-syncable-store-backing-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncBatchContentsForPath } from '../../internal/utils/getSyncBatchContentsForPath.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const getBundleAtPathForSync = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: SyncableStore, path: SyncablePath, { strategy }: { strategy: SyncStrategy }) =>
-    await isSyncableValidationEnabledProvider(
+  disableSyncableValidation(
+    async (
       trace,
-      false,
-      async (
-        trace
-      ): PR<{
-        metadata: SyncableItemMetadata;
-        metadataById: Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>;
-        batchContents?: SyncBatchContents;
-      }> => {
-        const bundle = await getSyncableAtPath(trace, store, path, 'bundle');
-        if (!bundle.ok) {
-          return generalizeFailureResult(trace, bundle, ['not-found', 'untrusted', 'wrong-type']);
-        }
-
-        let batchContents: SyncBatchContents | undefined;
-        switch (strategy) {
-          case 'default':
-            break; // Nothing special to do
-          case 'batch': {
-            // Loading batches is always best effort
-            const loaded = await getSyncBatchContentsForPath(trace, store, path);
-            if (loaded.ok) {
-              batchContents = loaded.value;
-            }
-          }
-        }
-
-        return await allResultsNamed(
-          trace,
-          {},
-          {
-            metadata: bundle.value.getMetadata(trace),
-            metadataById: bundle.value.getMetadataById(trace),
-            batchContents: Promise.resolve(makeSuccess(batchContents))
-          }
-        );
+      store: SyncableStore,
+      path: SyncablePath,
+      { strategy }: { strategy: SyncStrategy }
+    ): PR<{
+      metadata: SyncableItemMetadata;
+      metadataById: Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>;
+      batchContents?: SyncBatchContents;
+    }> => {
+      const bundle = await getSyncableAtPath(trace, store, path, 'bundle');
+      if (!bundle.ok) {
+        return generalizeFailureResult(trace, bundle, ['not-found', 'untrusted', 'wrong-type']);
       }
-    )
+
+      let batchContents: SyncBatchContents | undefined;
+      switch (strategy) {
+        case 'default':
+          break; // Nothing special to do
+        case 'batch': {
+          // Loading batches is always best effort
+          const loaded = await getSyncBatchContentsForPath(trace, store, path);
+          if (loaded.ok) {
+            batchContents = loaded.value;
+          }
+        }
+      }
+
+      return await allResultsNamed(
+        trace,
+        {},
+        {
+          metadata: bundle.value.getMetadata(trace),
+          metadataById: bundle.value.getMetadataById(trace),
+          batchContents: Promise.resolve(makeSuccess(batchContents))
+        }
+      );
+    }
+  )
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getFileAtPathForSync.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getFileAtPathForSync.ts
@@ -1,28 +1,27 @@
-import type { PR } from 'freedom-async';
 import { allResultsNamed, makeAsyncResultFunc } from 'freedom-async';
 import { generalizeFailureResult } from 'freedom-common-errors';
-import type { SyncableItemMetadata, SyncablePath, SyncStrategy } from 'freedom-sync-types';
+import type { SyncablePath, SyncStrategy } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const getFileAtPathForSync = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: SyncableStore, path: SyncablePath, _options: { strategy: SyncStrategy }) =>
-    await isSyncableValidationEnabledProvider(trace, false, async (trace): PR<{ data: Uint8Array; metadata: SyncableItemMetadata }> => {
-      const file = await getSyncableAtPath(trace, store, path, 'file');
-      if (!file.ok) {
-        return generalizeFailureResult(trace, file, ['not-found', 'untrusted', 'wrong-type']);
-      }
+  disableSyncableValidation(async (trace, store: SyncableStore, path: SyncablePath, _options: { strategy: SyncStrategy }) => {
+    const file = await getSyncableAtPath(trace, store, path, 'file');
+    if (!file.ok) {
+      return generalizeFailureResult(trace, file, ['not-found', 'untrusted', 'wrong-type']);
+    }
 
-      return await allResultsNamed(
-        trace,
-        {},
-        {
-          data: file.value.getEncodedBinary(trace),
-          metadata: file.value.getMetadata(trace)
-        }
-      );
-    })
+    return await allResultsNamed(
+      trace,
+      {},
+      {
+        data: file.value.getEncodedBinary(trace),
+        metadata: file.value.getMetadata(trace)
+      }
+    );
+  })
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getFolderAtPathForSync.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getFolderAtPathForSync.ts
@@ -5,50 +5,51 @@ import type { SyncableId, SyncableItemMetadata, SyncablePath, SyncBatchContents,
 import type { LocalItemMetadata } from 'freedom-syncable-store-backing-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncBatchContentsForPath } from '../../internal/utils/getSyncBatchContentsForPath.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
+// TODO: reenable validation in a smarter way
 export const getFolderAtPathForSync = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: SyncableStore, path: SyncablePath, { strategy }: { strategy: SyncStrategy }) =>
-    await isSyncableValidationEnabledProvider(
+  disableSyncableValidation(
+    async (
       trace,
-      false,
-      async (
-        trace
-      ): PR<{
-        metadata: SyncableItemMetadata;
-        metadataById: Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>;
-        batchContents?: SyncBatchContents;
-      }> => {
-        const folder = await getSyncableAtPath(trace, store, path, 'folder');
-        if (!folder.ok) {
-          return generalizeFailureResult(trace, folder, ['not-found', 'untrusted', 'wrong-type']);
-        }
-
-        let batchContents: SyncBatchContents | undefined;
-        switch (strategy) {
-          case 'default':
-            break; // Nothing special to do
-          case 'batch': {
-            // Loading batches is always best effort
-            const loaded = await getSyncBatchContentsForPath(trace, store, path);
-            if (loaded.ok) {
-              batchContents = loaded.value;
-            }
-          }
-        }
-
-        return await allResultsNamed(
-          trace,
-          {},
-          {
-            metadata: folder.value.getMetadata(trace),
-            metadataById: folder.value.getMetadataById(trace),
-            batchContents: Promise.resolve(makeSuccess(batchContents))
-          }
-        );
+      store: SyncableStore,
+      path: SyncablePath,
+      { strategy }: { strategy: SyncStrategy }
+    ): PR<{
+      metadata: SyncableItemMetadata;
+      metadataById: Partial<Record<SyncableId, SyncableItemMetadata & LocalItemMetadata>>;
+      batchContents?: SyncBatchContents;
+    }> => {
+      const folder = await getSyncableAtPath(trace, store, path, 'folder');
+      if (!folder.ok) {
+        return generalizeFailureResult(trace, folder, ['not-found', 'untrusted', 'wrong-type']);
       }
-    )
+
+      let batchContents: SyncBatchContents | undefined;
+      switch (strategy) {
+        case 'default':
+          break; // Nothing special to do
+        case 'batch': {
+          // Loading batches is always best effort
+          const loaded = await getSyncBatchContentsForPath(trace, store, path);
+          if (loaded.ok) {
+            batchContents = loaded.value;
+          }
+        }
+      }
+
+      return await allResultsNamed(
+        trace,
+        {},
+        {
+          metadata: folder.value.getMetadata(trace),
+          metadataById: folder.value.getMetadataById(trace),
+          batchContents: Promise.resolve(makeSuccess(batchContents))
+        }
+      );
+    }
+  )
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getSyncableItemTypeAtPathForSync.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/sync/getSyncableItemTypeAtPathForSync.ts
@@ -4,18 +4,18 @@ import { generalizeFailureResult } from 'freedom-common-errors';
 import type { SyncableItemType, SyncablePath } from 'freedom-sync-types';
 import type { SyncableStore } from 'freedom-syncable-store-types';
 
-import { isSyncableValidationEnabledProvider } from '../../internal/context/isSyncableValidationEnabled.ts';
+import { disableSyncableValidation } from '../../internal/context/isSyncableValidationEnabled.ts';
 import { getSyncableAtPath } from '../get/getSyncableAtPath.ts';
 
 export const getSyncableItemTypeAtPathForSync = makeAsyncResultFunc(
   [import.meta.filename],
-  async (trace, store: SyncableStore, path: SyncablePath) =>
-    await isSyncableValidationEnabledProvider(trace, false, async (trace): PR<SyncableItemType> => {
-      const localItemAccessor = await getSyncableAtPath(trace, store, path);
-      if (!localItemAccessor.ok) {
-        return generalizeFailureResult(trace, localItemAccessor, ['not-found', 'untrusted', 'wrong-type']);
-      }
+  disableSyncableValidation(async (trace, store: SyncableStore, path: SyncablePath): PR<SyncableItemType, 'not-found'> => {
+    const localItemAccessor = await getSyncableAtPath(trace, store, path);
+    if (!localItemAccessor.ok) {
+      return generalizeFailureResult(trace, localItemAccessor, ['untrusted', 'wrong-type']);
+    }
 
-      return makeSuccess(localItemAccessor.value.type);
-    })
+    return makeSuccess(localItemAccessor.value.type);
+  }),
+  { deepDisableLam: 'not-found' }
 );

--- a/code/cross-platform-packages/freedom-syncable-store/src/utils/validation/isTrustedTimeValid.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/utils/validation/isTrustedTimeValid.ts
@@ -50,7 +50,7 @@ export const isTrustedTimeValid = makeAsyncResultFunc(
       });
     }
 
-    const trustedTimeSources = await disableLam(trace, 'untrusted', (trace) => getTrustedTimeSourcesForPath(trace, store, parentPath));
+    const trustedTimeSources = await disableLam('untrusted', getTrustedTimeSourcesForPath)(trace, store, parentPath);
     if (!trustedTimeSources.ok) {
       if (trustedTimeSources.value.errorCode === 'untrusted') {
         return makeSuccess(false);

--- a/code/cross-platform-packages/freedom-trace-logging-and-metrics/src/logging-and-metrics.ts
+++ b/code/cross-platform-packages/freedom-trace-logging-and-metrics/src/logging-and-metrics.ts
@@ -18,8 +18,10 @@ const LoggingAndMetricsControlContext = createTraceContext<LoggingAndMetricsCont
 export const useLamControl = (trace: Trace) => useTraceContext(trace, LoggingAndMetricsControlContext);
 
 /** Disable logging and metrics for sub-trace */
-export const disableLam = <ReturnT>(trace: Trace, disable: DisableErrorsForLoggingAndMetrics, callback: (trace: Trace) => ReturnT) =>
-  lamControlModifier(trace, { disable }, callback);
+export const disableLam =
+  <ArgsT extends any[], ReturnT>(disable: DisableErrorsForLoggingAndMetrics, callback: (trace: Trace, ...args: ArgsT) => ReturnT) =>
+  (trace: Trace, ...args: ArgsT) =>
+    lamControlModifier(trace, { disable }, (trace) => callback(trace, ...args));
 
 export const lamControlModifier = <ReturnT>(
   trace: Trace,

--- a/code/server-packages/freedom-file-system-syncable-store-backing/src/types/FileSystemSyncableStoreBacking.ts
+++ b/code/server-packages/freedom-file-system-syncable-store-backing/src/types/FileSystemSyncableStoreBacking.ts
@@ -67,7 +67,7 @@ export class FileSystemSyncableStoreBacking implements SyncableStoreBacking {
   public readonly existsAtPath = makeAsyncResultFunc(
     [import.meta.filename, 'existsAtPath'],
     async (trace, path: SyncablePath): PR<boolean> => {
-      const found = await disableLam(trace, 'not-found', (trace) => traversePath(trace, this.root_, path));
+      const found = await disableLam('not-found', traversePath)(trace, this.root_, path);
       if (!found.ok) {
         if (found.value.errorCode === 'not-found') {
           return makeSuccess(false);

--- a/code/web-packages/freedom-indexeddb-object-store/src/types/IndexedDbObjectStore.ts
+++ b/code/web-packages/freedom-indexeddb-object-store/src/types/IndexedDbObjectStore.ts
@@ -75,9 +75,10 @@ export class IndexedDbObjectStore<KeyT extends string, T> implements MutableObje
 
         const lockKey = `${this.db_.name}.${this.storeName_}.${key}`;
         const completed = await withAcquiredLock(trace, lockStore.lock(lockKey), {}, async (): PR<T, 'conflict'> => {
-          const existingValue = await disableLam(trace, 'not-found', (trace) =>
-            readKv<KeyT, JsonValue>(trace, this.db_, { storeName: this.storeName_, key })
-          );
+          const existingValue = await disableLam('not-found', readKv<KeyT, JsonValue>)(trace, this.db_, {
+            storeName: this.storeName_,
+            key
+          });
           if (!existingValue.ok) {
             if (existingValue.value.errorCode === 'not-found') {
               const created = await writeKv<KeyT, JsonValue>(trace, this.db_, {
@@ -134,9 +135,7 @@ export class IndexedDbObjectStore<KeyT extends string, T> implements MutableObje
 
         const lockKey = `${this.db_.name}.${this.storeName_}.${key}`;
         const completed = await withAcquiredLock(trace, lockStore.lock(lockKey), {}, async (): PR<undefined, 'not-found'> => {
-          const found = await disableLam(trace, 'not-found', (trace) =>
-            readKv<KeyT, JsonValue>(trace, this.db_, { storeName: this.storeName_, key })
-          );
+          const found = await disableLam('not-found', readKv<KeyT, JsonValue>)(trace, this.db_, { storeName: this.storeName_, key });
           if (!found.ok) {
             return found;
           }
@@ -168,9 +167,7 @@ export class IndexedDbObjectStore<KeyT extends string, T> implements MutableObje
             lockStore.lock(lockKey),
             {},
             async (): PR<undefined, 'not-found' | 'out-of-date'> => {
-              const found = await disableLam(trace, 'not-found', (trace) =>
-                readKv<KeyT, JsonValue>(trace, this.db_, { storeName: this.storeName_, key })
-              );
+              const found = await disableLam('not-found', readKv<KeyT, JsonValue>)(trace, this.db_, { storeName: this.storeName_, key });
               if (!found.ok) {
                 return found;
               }
@@ -224,9 +221,7 @@ export class IndexedDbObjectStore<KeyT extends string, T> implements MutableObje
   public object(key: KeyT): ObjectAccessor<T> {
     return {
       exists: makeAsyncResultFunc([import.meta.filename, 'object', 'exists'], async (trace): PR<boolean> => {
-        const found = await disableLam(trace, 'not-found', (trace) =>
-          readKv<KeyT, JsonValue>(trace, this.db_, { storeName: this.storeName_, key })
-        );
+        const found = await disableLam('not-found', readKv<KeyT, JsonValue>)(trace, this.db_, { storeName: this.storeName_, key });
         if (!found.ok) {
           if (found.value.errorCode === 'not-found') {
             return makeSuccess(false);

--- a/code/web-worker-packages/freedom-email-tasks-web-worker/src/internal/tasks/mail/routeMail.ts
+++ b/code/web-worker-packages/freedom-email-tasks-web-worker/src/internal/tasks/mail/routeMail.ts
@@ -115,9 +115,7 @@ const hasMailBeenProcessedForRoutingAlready = makeAsyncResultFunc(
     const paths = await getUserMailPaths(syncableStore);
 
     const routeProcessedMarkerFilePath = paths.routeProcessing.year(mailDate).month.day.hour.mailId(mailId);
-    const syncableItem = await disableLam(trace, 'not-found', (trace) =>
-      getSyncableAtPath(trace, syncableStore, routeProcessedMarkerFilePath, 'file')
-    );
+    const syncableItem = await disableLam('not-found', getSyncableAtPath)(trace, syncableStore, routeProcessedMarkerFilePath, 'file');
     if (!syncableItem.ok) {
       if (syncableItem.value.errorCode === 'not-found') {
         return makeSuccess(false);

--- a/code/web-worker-packages/freedom-email-tasks-web-worker/src/internal/utils/createMailIdMarkerFile.ts
+++ b/code/web-worker-packages/freedom-email-tasks-web-worker/src/internal/utils/createMailIdMarkerFile.ts
@@ -33,7 +33,7 @@ export const createMailIdMarkerFile = makeAsyncResultFunc(
 
     const markerPath = yearPath.month.day.hour.mailId(mailId);
 
-    const created = await disableLam(trace, 'conflict', (trace) => createBinaryFileAtPath(trace, userFs, markerPath, { value: MARKER }));
+    const created = await disableLam('conflict', createBinaryFileAtPath)(trace, userFs, markerPath, { value: MARKER });
     if (!created.ok) {
       // Treating conflict as success, since it means the file already exists
       if (created.value.errorCode !== 'conflict') {

--- a/code/web-worker-packages/freedom-email-tasks-web-worker/src/tasks/user/startSyncService.ts
+++ b/code/web-worker-packages/freedom-email-tasks-web-worker/src/tasks/user/startSyncService.ts
@@ -60,13 +60,9 @@ export const startSyncService = makeAsyncResultFunc(
     // These will typically fail if we're recovering an account from the remote -- because the storage folder won't exist locally yet, but
     // that's ok, it means the remote already has the access it needs.
     // Giving Appender Access on the Storage Folder to the Server
-    await disableLam(trace, true, (trace) =>
-      bestEffort(trace, grantAppenderAccessOnStorageFolderToRemote(trace, credential, { remotePublicKeys }))
-    );
+    await disableLam(true, bestEffort)(trace, grantAppenderAccessOnStorageFolderToRemote(trace, credential, { remotePublicKeys }));
     // Giving Editor Access on the Out Folder to the Server
-    await disableLam(trace, true, (trace) =>
-      bestEffort(trace, grantEditorAccessOnOutFolderToRemote(trace, credential, { remotePublicKeys }))
-    );
+    await disableLam(true, bestEffort)(trace, grantEditorAccessOnOutFolderToRemote(trace, credential, { remotePublicKeys }));
 
     const startedRoutingMail = await routeMail(trace, credential);
     if (!startedRoutingMail.ok) {

--- a/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/internal/utils/makeExistsFuncForFilePath.ts
+++ b/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/internal/utils/makeExistsFuncForFilePath.ts
@@ -7,7 +7,7 @@ import { getFileHandleForSyncablePath } from './getFileHandleForSyncablePath.ts'
 
 export const makeExistsFuncForFilePath = (rootHandle: FileSystemDirectoryHandle, path: SyncablePath) =>
   makeAsyncResultFunc([import.meta.filename], async (trace): PR<boolean, 'wrong-type'> => {
-    const fileHandle = await disableLam(trace, 'not-found', (trace) => getFileHandleForSyncablePath(trace, rootHandle, path));
+    const fileHandle = await disableLam('not-found', getFileHandleForSyncablePath)(trace, rootHandle, path);
     if (!fileHandle.ok) {
       if (fileHandle.value.errorCode === 'not-found') {
         return makeSuccess(false);

--- a/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/internal/utils/makeExistsFuncForFolderPath.ts
+++ b/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/internal/utils/makeExistsFuncForFolderPath.ts
@@ -8,7 +8,7 @@ import { getFileHandleForSyncablePath } from './getFileHandleForSyncablePath.ts'
 
 export const makeExistsFuncForFolderPath = (rootHandle: FileSystemDirectoryHandle, path: SyncablePath) =>
   makeAsyncResultFunc([import.meta.filename], async (trace, id?: SyncableId): PR<boolean, 'wrong-type'> => {
-    const dir = await disableLam(trace, 'not-found', (trace) => getDirectoryHandle(trace, rootHandle, path));
+    const dir = await disableLam('not-found', getDirectoryHandle)(trace, rootHandle, path);
     if (!dir.ok) {
       if (dir.value.errorCode === 'not-found') {
         return makeSuccess(false);
@@ -20,9 +20,7 @@ export const makeExistsFuncForFolderPath = (rootHandle: FileSystemDirectoryHandl
       const itemType = extractSyncableItemTypeFromId(id);
       switch (itemType) {
         case 'file': {
-          const fileHandle = await disableLam(trace, 'not-found', (trace) =>
-            getFileHandleForSyncablePath(trace, rootHandle, path.append(id))
-          );
+          const fileHandle = await disableLam('not-found', getFileHandleForSyncablePath)(trace, rootHandle, path.append(id));
           if (!fileHandle.ok) {
             if (fileHandle.value.errorCode === 'not-found') {
               return makeSuccess(false);
@@ -34,7 +32,7 @@ export const makeExistsFuncForFolderPath = (rootHandle: FileSystemDirectoryHandl
         }
         case 'bundle':
         case 'folder': {
-          const dirHandle = await disableLam(trace, 'not-found', (trace) => getDirectoryHandle(trace, rootHandle, path.append(id)));
+          const dirHandle = await disableLam('not-found', getDirectoryHandle)(trace, rootHandle, path.append(id));
           if (!dirHandle.ok) {
             if (dirHandle.value.errorCode === 'not-found') {
               return makeSuccess(false);

--- a/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/types/OpfsSyncableStoreBacking.ts
+++ b/code/web-worker-packages/freedom-opfs-syncable-store-backing/src/types/OpfsSyncableStoreBacking.ts
@@ -63,7 +63,7 @@ export class OpfsSyncableStoreBacking implements SyncableStoreBacking {
   public readonly existsAtPath = makeAsyncResultFunc(
     [import.meta.filename, 'existsAtPath'],
     async (trace, path: SyncablePath): PR<boolean> => {
-      const found = await disableLam(trace, 'not-found', (trace) => traversePath(trace, this.root_, path));
+      const found = await disableLam('not-found', traversePath)(trace, this.root_, path);
       if (!found.ok) {
         if (found.value.errorCode === 'not-found') {
           return makeSuccess(false);


### PR DESCRIPTION
- disableLam is now used to wrap functions rather than calls and now returns a function that takes a trace and the args.  This makes it less verbose and usable in more places
- added deepDisableLam option for functions, which lets one disableLam for the function result as well as for anything within the trace of the function itself
- All TraceableErrors now try to get and log JS stack traces (DEV build only)
- also added disableSyncableValidation which, like disableLam, returns a function and is cleaner to use in many places, compared to isSyncableValidationEnabledProvider