### PR TITLE
Nested Locks

### DIFF
--- a/code/cross-platform-packages/freedom-locking-types/src/types/InMemoryLockStore.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/types/InMemoryLockStore.ts
@@ -22,6 +22,7 @@ export class InMemoryLockStore<KeyT extends string> implements LockStore<KeyT> {
 
   public lock(key: KeyT): Lock {
     return {
+      uid: `${this.uid}.${key}`,
       acquire: makeAsyncResultFunc(
         [import.meta.filename, 'acquire'],
         async (

--- a/code/cross-platform-packages/freedom-locking-types/src/types/Lock.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/types/Lock.ts
@@ -4,6 +4,8 @@ import type { LockOptions } from './LockOptions.ts';
 import type { LockToken } from './LockToken.ts';
 
 export interface Lock {
+  readonly uid: string;
+
   /**
    * Attempts to acquire this lock.
    *

--- a/code/cross-platform-packages/freedom-locking-types/src/types/acquired-locks.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/types/acquired-locks.ts
@@ -1,0 +1,16 @@
+import type { Trace } from 'freedom-contexts';
+import { createTraceContext, useTraceContext } from 'freedom-contexts';
+
+const AcquiredLocksContext = createTraceContext<{ acquiredLockUids: Readonly<Set<string>> }>(() => ({ acquiredLockUids: new Set() }));
+
+export const useAcquiredLocks = (trace: Trace) => useTraceContext(trace, AcquiredLocksContext);
+
+export const acquiredLocksProvider = <ReturnT>(
+  trace: Trace,
+  { acquiredLockUids }: { acquiredLockUids: string[] },
+  callback: (trace: Trace) => ReturnT
+) => {
+  const ancestorValue = useAcquiredLocks(trace);
+  const newValue = new Set([...ancestorValue.acquiredLockUids, ...acquiredLockUids]);
+  return AcquiredLocksContext.provider(trace, { acquiredLockUids: newValue }, callback);
+};

--- a/code/cross-platform-packages/freedom-locking-types/src/types/exports.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/types/exports.ts
@@ -1,3 +1,4 @@
+export * from './acquired-locks.ts';
 export * from './InMemoryLockStore.ts';
 export * from './Lock.ts';
 export * from './LockOptions.ts';

--- a/code/cross-platform-packages/freedom-locking-types/src/utils/__tests__/withAcquiredLock.test.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/utils/__tests__/withAcquiredLock.test.ts
@@ -21,6 +21,23 @@ describe('withAcquiredLock', () => {
     expectOk(result);
   });
 
+  it('should work with nesting', async (_t: TestContext) => {
+    const trace = makeTrace('test');
+    const locksStore = new InMemoryLockStore();
+
+    const result1 = await withAcquiredLock(trace, locksStore.lock('a'), { timeoutMSec: 1000 }, async (trace) => {
+      const result2 = await withAcquiredLock(trace, locksStore.lock('a'), { timeoutMSec: 1000 }, async (_trace) => {
+        await sleep(Math.random() * 100);
+        return makeSuccess(undefined);
+      });
+      expectOk(result2);
+
+      return makeSuccess(undefined);
+    });
+
+    expectOk(result1);
+  });
+
   it('should return timeout error if lock cannot be acquired before the specified timeout', async (_t: TestContext) => {
     const trace = makeTrace('test');
     const locksStore = new InMemoryLockStore();

--- a/code/cross-platform-packages/freedom-locking-types/src/utils/withAcquiredLock.ts
+++ b/code/cross-platform-packages/freedom-locking-types/src/utils/withAcquiredLock.ts
@@ -2,6 +2,7 @@ import type { PR, PRFunc } from 'freedom-async';
 import { makeAsyncResultFunc } from 'freedom-async';
 import type { Trace } from 'freedom-contexts';
 
+import { acquiredLocksProvider, useAcquiredLocks } from '../types/acquired-locks.ts';
 import type { Lock } from '../types/Lock.ts';
 import type { LockOptions } from '../types/LockOptions.ts';
 
@@ -13,13 +14,19 @@ export const withAcquiredLock = makeAsyncResultFunc(
     options: LockOptions,
     callback: PRFunc<SuccessT, ErrorCodeT>
   ): PR<SuccessT, ErrorCodeT | 'lock-timeout'> => {
+    // If the lock was already acquired in the current trace, we shouldn't try to acquire it again.
+    const acquiredLocks = useAcquiredLocks(trace);
+    if (acquiredLocks.acquiredLockUids.has(lock.uid)) {
+      return await callback(trace);
+    }
+
     const lockToken = await lock.acquire(trace, options);
     if (!lockToken.ok) {
       return lockToken;
     }
 
     try {
-      return await callback(trace);
+      return await acquiredLocksProvider(trace, { acquiredLockUids: [lock.uid] }, callback);
     } finally {
       // Ignoring errors during lock release
       await lock.release(trace, lockToken.value);


### PR DESCRIPTION
- If the same lock is used in a nested fashion with withAcquiredLock, it will automatically be allowed and not try to acquire (and deadlock)
- useAcquiredLocks is now available as a trace hook -- it allows one to look up the uids of acquired locks within a trace