### PR TITLE
Updated Lint Rules and Updated freedom-config

### DIFF
--- a/code/apps/freedom-email-app/src/modules/mail-collection/hooks/useMailCollectionDataSource.ts
+++ b/code/apps/freedom-email-app/src/modules/mail-collection/hooks/useMailCollectionDataSource.ts
@@ -46,7 +46,7 @@ export const useMailCollectionDataSource = (): DataSource<MailCollectionDataSour
   useBindingEffect(
     selectedCollectionId,
     (selectedCollectionId, selectedCollectionBinding) => {
-      if (!tasks) {
+      if (tasks === undefined) {
         return;
       }
 

--- a/code/apps/freedom-email-app/src/modules/mail-collections-list/hooks/useMailCollectionsListDataSource.ts
+++ b/code/apps/freedom-email-app/src/modules/mail-collections-list/hooks/useMailCollectionsListDataSource.ts
@@ -39,7 +39,7 @@ export const useMailCollectionsListDataSource = (): DataSource<MailCollectionsLi
   }, [tasks]);
 
   useEffect(() => {
-    if (!tasks) {
+    if (tasks === undefined) {
       return;
     }
 

--- a/code/apps/freedom-email-app/src/modules/mail-thread/hooks/useMailThreadDataSource.ts
+++ b/code/apps/freedom-email-app/src/modules/mail-thread/hooks/useMailThreadDataSource.ts
@@ -42,7 +42,7 @@ export const useMailThreadDataSource = (): DataSource<MailThreadDataSourceItem, 
   useBindingEffect(
     selectedThreadId,
     (selectedThreadId, selectedThreadIdBinding) => {
-      if (!tasks) {
+      if (tasks === undefined) {
         return;
       }
 

--- a/code/backends/freedom-mail-host/package.json
+++ b/code/backends/freedom-mail-host/package.json
@@ -8,6 +8,7 @@
     "freedom-email-server": "0.0.0",
     "freedom-email-sync": "0.0.0",
     "freedom-syncable-store-server": "0.0.0",
+    "luxon": "3.6.1",
     "mailparser": "3.7.2",
     "nodemailer": "6.10.1",
     "smtp-server": "3.13.6"

--- a/code/backends/freedom-mail-host/src/config.ts
+++ b/code/backends/freedom-mail-host/src/config.ts
@@ -11,18 +11,15 @@ const env = loadEnv(rootDir);
 // SMTP server
 
 /** Ports to run the SMTP server on (comma-separated list) */
-export const SMTP_PORTS = env
-  .get('SMTP_PORTS')
-  .required()
-  .asCustom((value) =>
-    value.split(',').map((port) => {
-      const portNum = parseInt(port.trim(), 10);
-      if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
-        throw new Error(`Invalid port number: '${port}'`);
-      }
-      return portNum;
-    })
-  ) as number[];
+export const SMTP_PORTS = env.getRequiredAsCustom('SMTP_PORTS', (value) =>
+  value.split(',').map((port) => {
+    const portNum = parseInt(port.trim(), 10);
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      throw new Error(`Invalid port number: '${port}'`);
+    }
+    return portNum;
+  })
+);
 
 /** Host to bind the SMTP server to */
 export const SMTP_HOST = env.get('SMTP_HOST').required().asString();
@@ -32,28 +29,21 @@ export const SMTP_HOST_NAME = env.get('SMTP_HOST_NAME').required().asString();
 
 /** TLS certificate path for SMTP server */
 export const SMTP_TLS_CERT_RAW =
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   (env.get('SMTP_TLS_CERT_RAW').asString() ?? '') ||
-  (env
-    .get('SMTP_TLS_CERT')
-    .required()
-    .asCustom((value) => fs.readFileSync(path.resolve(rootDir, value), 'utf8')) as string);
+  env.getRequiredAsCustom('SMTP_TLS_CERT', (value) => fs.readFileSync(path.resolve(rootDir, value), 'utf8'));
 
 /** TLS key path for SMTP server */
 export const SMTP_TLS_KEY_RAW =
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   (env.get('SMTP_TLS_KEY_RAW').asString() ?? '') ||
-  (env
-    .get('SMTP_TLS_KEY')
-    .required()
-    .asCustom((value) => fs.readFileSync(path.resolve(rootDir, value), 'utf8')) as string);
+  env.getRequiredAsCustom('SMTP_TLS_KEY', (value) => fs.readFileSync(path.resolve(rootDir, value), 'utf8'));
 
 /** Maximum email size in bytes */
 export const SMTP_MAX_EMAIL_SIZE = env.get('SMTP_MAX_EMAIL_SIZE').required().asInt();
 
 /** Domains we accept mail for */
-export const SMTP_OUR_DOMAINS = env
-  .get('SMTP_OUR_DOMAINS')
-  .required()
-  .asCustom((value) => value.split(',').map((domain) => domain.trim())) as string[];
+export const SMTP_OUR_DOMAINS = env.getRequiredAsCustom('SMTP_OUR_DOMAINS', (value) => value.split(',').map((domain) => domain.trim()));
 
 /** Forwarding routes */
 export const FORWARDING_ROUTES = JSON.parse(
@@ -73,16 +63,13 @@ export const SMTP_UPSTREAM_PORT = env.get('SMTP_UPSTREAM_PORT').default('25').as
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Storage
 
-export const STORAGE_ROOT_PATH = env
-  .get('STORAGE_ROOT_PATH')
-  .required()
-  .asCustom((value) => resolveConfigPath(rootDir, value)) as string;
+export const STORAGE_ROOT_PATH = env.getRequiredAsCustom('STORAGE_ROOT_PATH', (value) => resolveConfigPath(rootDir, value));
 
 // Temporary disabled in favor of File System Backing and a Docker volume
 // /** Google Cloud Storage credentials file contents (not name) */
 // export const GOOGLE_APPLICATION_CREDENTIALS_RAW =
-//   (env.get('GOOGLE_APPLICATION_CREDENTIALS_RAW').asCustom((value) => (value ? JSON.parse(value) : undefined)) as {} | undefined) ||
-//   (env.get('GOOGLE_APPLICATION_CREDENTIALS').asCustom((value) =>
+//   (env.getAsCustom('GOOGLE_APPLICATION_CREDENTIALS_RAW', (value) => (value ? JSON.parse(value) : undefined)) as {} | undefined) ||
+//   (env.getAsCustom('GOOGLE_APPLICATION_CREDENTIALS', (value) =>
 //     value ? JSON.parse(fs.readFileSync(path.resolve(rootDir, value), 'utf8')) : undefined // In GCP, we use machine-wise implicit credentials
 //   ) as {} | undefined);
 //

--- a/code/backends/freedom-mail-host/src/modules/smtp-server/actions/onValidateReceiver.ts
+++ b/code/backends/freedom-mail-host/src/modules/smtp-server/actions/onValidateReceiver.ts
@@ -21,7 +21,7 @@ export const onValidateReceiver: SmtpServerParams['onValidateReceiver'] = makeAs
     // Get the domain part of the email
     const [, domain] = emailAddress.split('@');
 
-    if (!domain) {
+    if (domain.length === 0) {
       return makeFailure(
         new NotFoundError(trace, {
           errorCode: 'malformed-email-address',

--- a/code/backends/freedom-mail-host/src/modules/smtp-server/internal/utils/__tests__/defineSmtpServer.test.ts
+++ b/code/backends/freedom-mail-host/src/modules/smtp-server/internal/utils/__tests__/defineSmtpServer.test.ts
@@ -331,7 +331,7 @@ describe('defineSmtpServer', () => {
       // Mock the validation function to return appropriate responses
       onValidateReceiver.mock.mockImplementation(async (_trace, email) => {
         const result = addressResponses.get(email);
-        if (!result) {
+        if (result === undefined) {
           throw new Error(`Unexpected email address: ${email}`);
         }
         return makeSuccess(result);
@@ -545,7 +545,7 @@ describe('defineSmtpServer', () => {
             });
 
             // Assert
-            if (expectError) {
+            if (expectError !== null) {
               await expect(clientResult).rejects.toThrow(expectError);
             } else {
               await clientResult;

--- a/code/backends/freedom-mail-host/src/modules/syncable-store/utils/routeMail.ts
+++ b/code/backends/freedom-mail-host/src/modules/syncable-store/utils/routeMail.ts
@@ -46,7 +46,7 @@ export const routeMail = makeAsyncResultFunc(
 
       // Classify
       const [, domain] = recipient.split('@');
-      if (domain && config.SMTP_OUR_DOMAINS.includes(domain)) {
+      if (domain.length > 0 && config.SMTP_OUR_DOMAINS.includes(domain)) {
         // Internal target
         internalRecipients.push(recipient);
       } else if (recipient !== denotedRecipient) {

--- a/code/backends/freedom-store-api-server/src/config.ts
+++ b/code/backends/freedom-store-api-server/src/config.ts
@@ -10,10 +10,7 @@ const env = loadEnv(rootDir);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Domains
 
-export const CORS_ORIGINS = env
-  .get('CORS_ORIGINS')
-  .required()
-  .asCustom((value) => value.split(',').map((domain) => domain.trim())) as string[];
+export const CORS_ORIGINS = env.getRequiredAsCustom('CORS_ORIGINS', (value) => value.split(',').map((domain) => domain.trim()));
 
 export const EMAIL_DOMAIN = env.get('EMAIL_DOMAIN').required().asString();
 
@@ -23,21 +20,20 @@ export const EMAIL_DOMAIN = env.get('EMAIL_DOMAIN').required().asString();
 export const PORT = env.get('PORT').required().asPortNumber();
 
 export const HTTPS_SERVER_CERT =
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   (env.get('HTTPS_SERVER_CERT_RAW').asString() ?? '') ||
-  (env.get('HTTPS_SERVER_CERT_PATH').asCustom((value) => value && fs.readFileSync(path.resolve(rootDir, value), 'utf8')) as
-    | string
-    | undefined);
+  env.getAsCustom('HTTPS_SERVER_CERT_PATH', (value) =>
+    value.length > 0 ? fs.readFileSync(path.resolve(rootDir, value), 'utf8') : undefined
+  );
 
 export const HTTPS_SERVER_KEY =
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   (env.get('HTTPS_SERVER_KEY_RAW').asString() ?? '') ||
-  (env.get('HTTPS_SERVER_KEY_PATH').asCustom((value) => value && fs.readFileSync(path.resolve(rootDir, value), 'utf8')) as
-    | string
-    | undefined);
+  env.getAsCustom('HTTPS_SERVER_KEY_PATH', (value) =>
+    value.length > 0 ? fs.readFileSync(path.resolve(rootDir, value), 'utf8') : undefined
+  );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Storage
 
-export const STORAGE_ROOT_PATH = env
-  .get('STORAGE_ROOT_PATH')
-  .required()
-  .asCustom((value) => resolveConfigPath(rootDir, value)) as string;
+export const STORAGE_ROOT_PATH = env.getRequiredAsCustom('STORAGE_ROOT_PATH', (value) => resolveConfigPath(rootDir, value));

--- a/code/cross-platform-packages/freedom-contexts/src/utils/wrapLoggingFunc.ts
+++ b/code/cross-platform-packages/freedom-contexts/src/utils/wrapLoggingFunc.ts
@@ -175,11 +175,11 @@ const makePrettyPrintLoggingFunc =
       paleLines.push(`  ${key}: ${formatPrettyPrintValue(value)}`);
     });
 
+    const message = (msgContent?.length ?? 0) > 0 ? msgContent : '<No message>';
+
     loggingFunc(
       // Form the main bright line and wrap the pale lines with 'faint' color
-      `${prettyTime} - ${paintedSeverity} - ${msgContent || '<No message>'}${
-        paleLines.length > 0 ? `\n\x1b[2m${paleLines.join('\n')}\x1b[0m` : ''
-      }`
+      `${prettyTime} - ${paintedSeverity} - ${message}${paleLines.length > 0 ? `\n\x1b[2m${paleLines.join('\n')}\x1b[0m` : ''}`
     );
   };
 

--- a/code/dev-packages/freedom-dev-scripts/src/package-sync/utils/findPackages.ts
+++ b/code/dev-packages/freedom-dev-scripts/src/package-sync/utils/findPackages.ts
@@ -15,7 +15,7 @@ export async function findPackages(): Promise<FoundPackage[]> {
 
   // Extract workspaces.packages patterns
   const workspacePatterns = rootPackage.workspaces?.packages ?? [];
-  if (!workspacePatterns.length) {
+  if (workspacePatterns.length === 0) {
     throw new Error('No workspace patterns found in root package.json');
   }
 

--- a/code/dev-packages/freedom-dev-scripts/src/package-sync/utils/utils.ts
+++ b/code/dev-packages/freedom-dev-scripts/src/package-sync/utils/utils.ts
@@ -11,6 +11,7 @@ export function isEffectiveValueObject(value: EffectiveValue): value is Effectiv
 }
 
 export function formatPath(path: PropertyPath): string {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   return path.join('.') || '.';
 }
 

--- a/code/eslint.config.mjs
+++ b/code/eslint.config.mjs
@@ -115,8 +115,22 @@ const baseConfig = [
       '@typescript-eslint/no-duplicate-type-constituents': 'off',
       '@typescript-eslint/no-use-before-define': 'off',
       '@typescript-eslint/require-await': 'off',
-      '@typescript-eslint/strict-boolean-expressions': 'error',
+      '@typescript-eslint/strict-boolean-expressions': [
+        'error',
+        {
+          allowAny: false,
+          allowNullableBoolean: false,
+          allowNullableEnum: false,
+          allowNullableNumber: false,
+          allowNullableObject: false,
+          allowNullableString: false,
+          allowNumber: false,
+          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
+          allowString: false
+        }
+      ],
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      curly: ['error', 'all'],
       'no-constant-condition': 'off',
       'no-extra-boolean-cast': 'off',
       'no-unused-labels': 'off',

--- a/code/server-packages/freedom-config/README.md
+++ b/code/server-packages/freedom-config/README.md
@@ -17,7 +17,7 @@ const port = env.get('PORT').default('3000').asInt();
 const host = env.get('HOST').default('localhost').asString();
 
 // Using custom validators
-const result = env.get('CUSTOM_VAR').asCustom((value) => {
+const result = env.getAsCustom('CUSTOM_VAR', (value) => {
   const [key, val] = value.split(':');
   return { key, value: Number(val) };
 });

--- a/code/server-packages/freedom-config/src/utils/__tests__/from.test.ts
+++ b/code/server-packages/freedom-config/src/utils/__tests__/from.test.ts
@@ -8,12 +8,10 @@ describe('from', () => {
 
   it('should implement custom validator', () => {
     // Act
-    const envValue = from(env)
-      .get('THE_VAR')
-      .asCustom((value: string) => {
-        const [key, val] = value.split(':');
-        return { key, value: Number(val) };
-      });
+    const envValue = from(env).getAsCustom('THE_VAR', (value: string) => {
+      const [key, val] = value.split(':');
+      return { key, value: Number(val) };
+    });
 
     // Assert
     assert.deepStrictEqual(envValue, { key: 'value', value: 123 });
@@ -23,11 +21,9 @@ describe('from', () => {
     assert.throws(
       // Act
       () =>
-        from(env)
-          .get('THE_VAR')
-          .asCustom(() => {
-            throw new Error('The error message');
-          }),
+        from(env).getAsCustom('THE_VAR', () => {
+          throw new Error('The error message');
+        }),
       // Assert
       { message: 'env-var: "THE_VAR" The error message' }
     );

--- a/code/server-packages/freedom-config/src/utils/from.ts
+++ b/code/server-packages/freedom-config/src/utils/from.ts
@@ -1,26 +1,47 @@
-import type { Extensions } from 'env-var';
 import envVar from 'env-var';
 
-/**
- * Extends the env-var variable with custom validators
- */
-const extensions = {
+export interface ExtendedFrom<Container extends Record<string, string | undefined>> {
   /**
-   * Custom validator that allows transforming the string value to any type
-   * @param value - The env variable value
-   * @param validator - Function that validates and transforms the string value
+   * Gets the specified environment variable and, if it is set, applies the custom transformer.
+   * @param varName - The name of the environment variable to get
+   * @param transformer - Function that validates and transforms the string value
+   * @returns The transformed value or `undefined` if the environment variable isn't set
+   */
+  getAsCustom<T>(varName: keyof Container, transformer: (value: string) => T): T | undefined;
+
+  /**
+   * Gets the specified environment variable and, if it is not set, throws an error.
+   * @param varName - The name of the environment variable to get
+   * @param transformer - Function that validates and transforms the string value
    * @returns The transformed value
    */
-  asCustom<T>(value: string, validator: (value: string) => T): T {
-    return validator(value);
-  }
-} satisfies Extensions;
+  getRequiredAsCustom<T>(varName: keyof Container, transformer: (value: string) => T): T;
+}
 
 /**
  * Enhanced version of env-var's from function with custom validators
  * @param env - Object containing environment variables (process.env on backend, import.meta.env on frontend)
  * @returns Enhanced env-var instance with custom validators
  */
-export function from(env: Record<string, string | undefined>) {
-  return envVar.from(env, extensions);
+export function from<Container extends Record<string, string | undefined>>(env: Container) {
+  const defaultFrom = envVar.from(env);
+
+  const out = defaultFrom as typeof defaultFrom & Partial<ExtendedFrom<Container>>;
+
+  out.getAsCustom = <T>(varName: keyof Container, transformer: (value: string) => T): T | undefined => {
+    const value = defaultFrom.get(varName).asString();
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return transformer(value);
+  };
+
+  out.getRequiredAsCustom = <T>(varName: keyof Container, transformer: (value: string) => T): T => {
+    const value = defaultFrom.get(varName).required().asString();
+
+    return transformer(value);
+  };
+
+  return out as typeof defaultFrom & ExtendedFrom<Container>;
 }

--- a/code/server-packages/freedom-config/src/utils/loadEnv.ts
+++ b/code/server-packages/freedom-config/src/utils/loadEnv.ts
@@ -39,6 +39,7 @@ function config(options: DotenvConfigOptions) {
  * @returns True if at least one .env file was loaded, false otherwise
  */
 export function loadEnv(rootDir: string) {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const nodeEnv = (myProcess.env.NODE_ENV ?? '') || 'development';
 
   if (nodeEnv === 'test') {

--- a/code/server-packages/freedom-email-server/src/utils/subscribeOnOutboundEmails.ts
+++ b/code/server-packages/freedom-email-server/src/utils/subscribeOnOutboundEmails.ts
@@ -28,7 +28,9 @@ export const subscribeOnOutboundEmails = makeAsyncResultFunc(
 
     // Helper function to fetch the latest outbound emails for a specific user
     async function pollOutboundEmailsForUser(user: User, syncableStore: MutableSyncableStore): Promise<void> {
-      if (!isActive) return;
+      if (!isActive) {
+        return;
+      }
 
       const result = await listOutboundMailIds(trace, syncableStore, {});
       if (!result.ok) {
@@ -40,7 +42,7 @@ export const subscribeOnOutboundEmails = makeAsyncResultFunc(
 
       // Get or initialize the set of last seen IDs for this user
       let lastSeenIds = lastSeenIdsByUser.get(user.userId);
-      if (!lastSeenIds) {
+      if (lastSeenIds === undefined) {
         lastSeenIds = new Set<string>();
         lastSeenIdsByUser.set(user.userId, lastSeenIds);
       }
@@ -61,7 +63,9 @@ export const subscribeOnOutboundEmails = makeAsyncResultFunc(
 
     // Poll outbound emails for all users
     async function pollAllUsers(): Promise<void> {
-      if (!isActive) return;
+      if (!isActive) {
+        return;
+      }
 
       const usersResult = await getAllUsers(trace);
 
@@ -75,7 +79,9 @@ export const subscribeOnOutboundEmails = makeAsyncResultFunc(
 
       // Process each user sequentially
       for (const user of users) {
-        if (!isActive) return;
+        if (!isActive) {
+          return;
+        }
 
         const syncableStore = await uncheckedResult(getEmailAgentSyncableStoreForUser(trace, user));
 


### PR DESCRIPTION
- Lint rules are now more strict about use of curly braces
- Also more strict about implicit boolean expressions
- Updated code as appropriate
- Updated freedom-config to be more type safe wrt asCustom
  - Replaced asCustom extension with getAsCustom and getRequiredAsCustom to avoid type erasure from generic function passed as extension