### PR TITLE
Implement getFileEnvVar, getJsonFileEnvVar in freedom-config

### DIFF
--- a/code/server-packages/freedom-config/src/utils/defineConfig.ts
+++ b/code/server-packages/freedom-config/src/utils/defineConfig.ts
@@ -20,7 +20,13 @@ export function defineConfig<Config extends Record<string, unknown>>(testDefault
    * @param config - Partial configuration object that overrides defaults
    */
   function initConfigForTests(config: Partial<Config>): void {
-    activeConfig = { ...testDefaults, ...config };
+    // Clone preserving testDefaults getters
+    activeConfig = Object.create({}, Object.getOwnPropertyDescriptors(testDefaults)) as Config;
+
+    // Apply overrides
+    for (const [key, value] of Object.entries(config)) {
+      activeConfig[key as keyof Config] = value as Config[keyof Config];
+    }
   }
 
   /**

--- a/code/server-packages/freedom-config/src/utils/exports.ts
+++ b/code/server-packages/freedom-config/src/utils/exports.ts
@@ -1,4 +1,6 @@
 export * from './defineConfig.ts';
 export * from './from.ts';
+export * from './getFileEnvVar.ts';
+export * from './getJsonFileEnvVar.ts';
 export * from './loadEnv.ts';
 export * from './resolveConfigPath.ts';

--- a/code/server-packages/freedom-config/src/utils/from.ts
+++ b/code/server-packages/freedom-config/src/utils/from.ts
@@ -1,6 +1,6 @@
-import envVar from 'env-var';
+import envVar, { type IDefaultEnv } from 'env-var';
 
-export interface ExtendedFrom<Container extends Record<string, string | undefined>> {
+export interface ExtendedFrom<Container extends NodeJS.ProcessEnv> {
   /**
    * Gets the specified environment variable and, if it is set, applies the custom transformer.
    * @param varName - The name of the environment variable to get
@@ -18,12 +18,14 @@ export interface ExtendedFrom<Container extends Record<string, string | undefine
   getRequiredAsCustom<T>(varName: keyof Container, transformer: (value: string) => T): T;
 }
 
+export type FreedomEnvVar<Container extends NodeJS.ProcessEnv> = IDefaultEnv & ExtendedFrom<Container>;
+
 /**
  * Enhanced version of env-var's from function with custom validators
  * @param env - Object containing environment variables (process.env on backend, import.meta.env on frontend)
  * @returns Enhanced env-var instance with custom validators
  */
-export function from<Container extends Record<string, string | undefined>>(env: Container) {
+export function from<Container extends NodeJS.ProcessEnv>(env: Container) {
   const defaultFrom = envVar.from(env);
 
   const out = defaultFrom as typeof defaultFrom & Partial<ExtendedFrom<Container>>;

--- a/code/server-packages/freedom-config/src/utils/getFileEnvVar.ts
+++ b/code/server-packages/freedom-config/src/utils/getFileEnvVar.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+
+import type { FreedomEnvVar } from './from.ts';
+import { resolveConfigPath } from './resolveConfigPath.ts';
+
+export function getFileEnvVar<T>(
+  env: FreedomEnvVar<NodeJS.ProcessEnv>,
+  rootDir: string,
+  // Reads from XXX_RAW then XXX_PATH
+  // End type with '_' to prevent wrong assumptions when reading the code
+  namePrefix: `${string}_`,
+  parser: (value: string) => T
+): T {
+  return (
+    env.getAsCustom(`${namePrefix}RAW`, (v) => (v !== '' ? parser(v) : undefined)) ??
+    env.getRequiredAsCustom(`${namePrefix}PATH`, (pathValue) => {
+      const value = fs.readFileSync(resolveConfigPath(rootDir, pathValue), 'utf8');
+      return parser(value);
+    })
+  );
+}

--- a/code/server-packages/freedom-config/src/utils/getJsonFileEnvVar.ts
+++ b/code/server-packages/freedom-config/src/utils/getJsonFileEnvVar.ts
@@ -1,0 +1,15 @@
+import type { Schema } from 'yaschema';
+
+import { getFileEnvVar } from './getFileEnvVar.ts';
+
+/**
+ * Schema-powered version of getFileEnvVar
+ */
+export function getJsonFileEnvVar<T>(
+  env: Parameters<typeof getFileEnvVar>[0],
+  rootDir: string,
+  namePrefix: `${string}_`,
+  schema: Schema<T>
+): T {
+  return getFileEnvVar(env, rootDir, namePrefix, (v) => schema.parse(v));
+}


### PR DESCRIPTION
@brianwestphal FYI. This was implemented before your refactoring on env-var extensions. I will unify the patterns later in an iteration on the config.