### PR TITLE
Fixed Redundant Metadata Computation on Item Creation

### DIFF
--- a/code/backends/freedom-mail-host/package.json
+++ b/code/backends/freedom-mail-host/package.json
@@ -4,6 +4,7 @@
     "freedom-common-errors": "0.0.0",
     "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
+    "freedom-crypto-data": "0.0.0",
     "freedom-db": "0.0.0",
     "freedom-email-server": "0.0.0",
     "freedom-email-sync": "0.0.0",

--- a/code/cross-platform-packages/freedom-syncable-store/src/internal/types/DefaultMutableSyncableItemAccessorBase.ts
+++ b/code/cross-platform-packages/freedom-syncable-store/src/internal/types/DefaultMutableSyncableItemAccessorBase.ts
@@ -146,7 +146,7 @@ export abstract class DefaultMutableSyncableItemAccessorBase implements MutableS
       }
 
       const parentPath = this.path.parentPath;
-      if (store !== undefined && parentPath !== undefined) {
+      if (parentPath !== undefined) {
         const marked = await markSyncableNeedsRecomputeLocalMetadataAtPath(trace, store, parentPath);
         /* node:coverage disable */
         if (!marked.ok) {

--- a/code/server-packages/freedom-config/package.json
+++ b/code/server-packages/freedom-config/package.json
@@ -1,9 +1,10 @@
 {
   "dependencies": {
     "@dotenvx/dotenvx": "1.41.0",
-    "freedom-contexts": "0.0.0",
     "dotenv": "16.5.0",
-    "env-var": "7.5.0"
+    "env-var": "7.5.0",
+    "freedom-contexts": "0.0.0",
+    "yaschema": "5.2.1"
   },
   "devDependencies": {
     "freedom-build-tools": "0.0.0",

--- a/code/server-packages/freedom-db/package.json
+++ b/code/server-packages/freedom-db/package.json
@@ -7,7 +7,6 @@
     "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-crypto-data": "0.0.0",
-    "freedom-crypto-service": "0.0.0",
     "freedom-email-sync": "0.0.0",
     "freedom-json-file-object-store": "0.0.0",
     "freedom-object-store-types": "0.0.0",

--- a/code/server-packages/freedom-email-server/package.json
+++ b/code/server-packages/freedom-email-server/package.json
@@ -2,15 +2,19 @@
   "dependencies": {
     "freedom-async": "0.0.0",
     "freedom-common-errors": "0.0.0",
+    "freedom-config": "0.0.0",
     "freedom-contexts": "0.0.0",
     "freedom-crypto-data": "0.0.0",
+    "freedom-crypto-service": "0.0.0",
     "freedom-db": "0.0.0",
     "freedom-email-sync": "0.0.0",
     "freedom-sync-types": "0.0.0",
     "freedom-syncable-store-server": "0.0.0",
-    "freedom-syncable-store-types": "0.0.0"
+    "freedom-syncable-store-types": "0.0.0",
+    "lodash-es": "4.17.21"
   },
   "devDependencies": {
+    "@types/lodash-es": "4.17.12",
     "freedom-build-tools": "0.0.0",
     "typescript": "5.8.3"
   },

--- a/code/server-packages/freedom-redlock-store/package.json
+++ b/code/server-packages/freedom-redlock-store/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "freedom-basic-data": "0.0.0",
     "freedom-build-tools": "0.0.0",
+    "luxon": "3.6.1",
     "typescript": "5.8.3"
   },
   "type": "module",


### PR DESCRIPTION
- We were clearing the metadata for the item and its ancestors on creation, when we were already computing the items metadata (especially for binary files).  Should have only invalidated the ancestors' metadata